### PR TITLE
Refinement mapping with weak-simulation support

### DIFF
--- a/examples/min_max.rs
+++ b/examples/min_max.rs
@@ -329,10 +329,7 @@ mod min_max1 {
 }
 
 mod min_max2 {
-    use std::{
-        cmp::{max, min},
-        usize,
-    };
+    use std::cmp::{max, min};
 
     use stateright::Model;
 
@@ -510,7 +507,6 @@ mod one_refine_two {
             &self,
             _concrete: &<MinMax1 as stateright::Model>::State,
         ) -> Self::AuxState {
-            ()
         }
 
         fn advance_aux_state(
@@ -520,7 +516,6 @@ mod one_refine_two {
             _action: &<MinMax1 as stateright::Model>::Action,
             _next_concrete: &<MinMax1 as stateright::Model>::State,
         ) -> Self::AuxState {
-            ()
         }
 
         fn refinement_map(
@@ -553,12 +548,11 @@ mod one_refine_two {
             abstract_model: abstractt,
         };
         let refinement_model = RefinementModel::new(concrete, mapper);
-        let checker = refinement_model
+
+        refinement_model
             .checker()
             .threads(num_cpus::get())
-            .spawn_dfs();
-
-        checker
+            .spawn_dfs()
     }
 
     pub fn refinement_serve(
@@ -572,12 +566,11 @@ mod one_refine_two {
             abstract_model: abstractt,
         };
         let refinement_model = RefinementModel::new(concrete, mapper);
-        let checker = refinement_model
+
+        refinement_model
             .checker()
             .threads(num_cpus::get())
-            .serve("127.0.0.1:3000");
-
-        checker
+            .serve("127.0.0.1:3000")
     }
 }
 
@@ -597,12 +590,11 @@ mod two_refine_one {
         abstract_model: MinMax1,
     }
 
-    /// we need auxiliary state to have refinement mapping from MinMax2 to MinMax1,
-    /// because MinMax2 only stores the min and max, while MinMax1 stores all the history.
-    /// so, our auxiliary state for MinMax2 is basically a history that store all the values MinMax2 has seen so far.
-    ///
-    /// M == INSTANCE MinMax1 WITH y <- h
-
+    // we need auxiliary state to have refinement mapping from MinMax2 to MinMax1,
+    // because MinMax2 only stores the min and max, while MinMax1 stores all the history.
+    // so, our auxiliary state for MinMax2 is basically a history that store all the values MinMax2 has seen so far.
+    //
+    // M == INSTANCE MinMax1 WITH y <- h
     type History = Vec<usize>;
 
     impl RefinementMapping<MinMax2, MinMax1> for Mapper2to1 {
@@ -687,12 +679,11 @@ mod two_refine_one {
             abstract_model: abstractt,
         };
         let refinement_model = RefinementModel::new(concrete, mapper);
-        let checker = refinement_model
+
+        refinement_model
             .checker()
             .threads(num_cpus::get())
-            .spawn_dfs();
-
-        checker
+            .spawn_dfs()
     }
 
     pub fn refinement_serve(
@@ -706,12 +697,11 @@ mod two_refine_one {
             abstract_model: abstractt,
         };
         let refinement_model = RefinementModel::new(concrete, mapper);
-        let checker = refinement_model
+
+        refinement_model
             .checker()
             .threads(num_cpus::get())
-            .serve("127.0.0.1:3000");
-
-        checker
+            .serve("127.0.0.1:3000")
     }
 }
 

--- a/examples/min_max.rs
+++ b/examples/min_max.rs
@@ -188,13 +188,13 @@ mod min_max1 {
 
     use crate::min_max2;
 
-    #[derive(Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq)]
     pub(crate) enum Turn {
         Input,
         Output,
     }
 
-    #[derive(Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq)]
     pub(crate) enum Response {
         Lo,
         Hi,
@@ -202,13 +202,13 @@ mod min_max1 {
         None,
     }
 
-    #[derive(Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq)]
     pub(crate) enum XType {
         Input(usize),
         Output(Response),
     }
 
-    #[derive(Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq)]
     pub(crate) struct MinMax1State {
         pub x: Option<XType>,
         pub turn: Turn,
@@ -217,7 +217,7 @@ mod min_max1 {
         pub idx: usize,
     }
 
-    #[derive(Clone, PartialEq)]
+    #[derive(Debug, Clone, PartialEq)]
     pub(crate) enum MinMax1Action {
         InputNum,
         Respond,
@@ -338,13 +338,13 @@ mod min_max2 {
 
     use crate::min_max1;
 
-    #[derive(Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq)]
     pub(crate) enum Turn {
         Input,
         Output,
     }
 
-    #[derive(Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq)]
     pub(crate) enum Response {
         Lo,
         Hi,
@@ -352,13 +352,13 @@ mod min_max2 {
         None,
     }
 
-    #[derive(Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq)]
     pub(crate) enum XType {
         Input(usize),
         Output(Response),
     }
 
-    #[derive(Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq)]
     pub(crate) struct MinMax2State {
         pub x: Option<XType>,
         pub turn: Turn,
@@ -368,7 +368,7 @@ mod min_max2 {
         pub idx: usize,
     }
 
-    #[derive(Clone, PartialEq)]
+    #[derive(Debug, Clone, PartialEq)]
     pub(crate) enum MinMax2Action {
         InputNum,
         Respond,
@@ -555,6 +555,25 @@ mod one_refine_two {
 
         checker
     }
+
+    pub fn refinement_serve(
+        user_input: Vec<usize>,
+    ) -> std::sync::Arc<impl Checker<RefinementModel<MinMax1, MinMax2, Mapper1to2>>> {
+        let concrete = MinMax1 {
+            user_input: user_input.clone(),
+        };
+        let abstractt = MinMax2 { user_input };
+        let mapper = Mapper1to2 {
+            abstract_model: abstractt,
+        };
+        let refinement_model = RefinementModel::new(concrete, mapper);
+        let checker = refinement_model
+            .checker()
+            .threads(num_cpus::get())
+            .serve("127.0.0.1:3000");
+
+        checker
+    }
 }
 
 mod two_refine_one {
@@ -598,23 +617,36 @@ mod two_refine_one {
 
         fn advance_aux_state(
             &self,
-            _last_concrete: &<MinMax2 as stateright::Model>::State,
+            last_concrete: &<MinMax2 as stateright::Model>::State,
             last_aux: &Self::AuxState,
             action: &<MinMax2 as stateright::Model>::Action,
-            next_concrete: &<MinMax2 as stateright::Model>::State,
+            _next_concrete: &<MinMax2 as stateright::Model>::State,
         ) -> Self::AuxState {
             let mut new_aux = last_aux.clone();
 
+            // NOTE: the following code is incorrect for the refinement mapping. Using the code will fail the refinement model checking.
+            // match action {
+            //     MinMax2Action::InputNum => {
+            //         // the newly inserted number is the next_concrete.x
+            //         if let Some(XType::Input(n)) = next_concrete.x {
+            //             new_aux.push(n);
+            //         } else {
+            //             panic!("State transition doesn't match with action. Action is InputNum, but next_state.x is not XType::Input.")
+            //         }
+            //     }
+            //     MinMax2Action::Respond => {} // no update is needed if action is Respond
+            // }
+
             match action {
-                MinMax2Action::InputNum => {
-                    // the newly inserted number is the next_concrete.x
-                    if let Some(XType::Input(n)) = next_concrete.x {
+                MinMax2Action::InputNum => {} // no update is needed if action is InputNum
+                MinMax2Action::Respond => {
+                    // the newly inserted number is the last_concrete.x
+                    if let Some(XType::Input(n)) = last_concrete.x {
                         new_aux.push(n);
                     } else {
-                        panic!("State transition doesn't match with action. Action is InputNum, but next_state.x is not XType::Input.")
+                        panic!("State transition doesn't match with action. Action is Respond, but last_concrete.x is not XType::Input.")
                     }
                 }
-                MinMax2Action::Respond => {} // no update is needed if action is Respond
             }
 
             new_aux
@@ -652,6 +684,25 @@ mod two_refine_one {
 
         checker
     }
+
+    pub fn refinement_serve(
+        user_input: Vec<usize>,
+    ) -> std::sync::Arc<impl Checker<RefinementModel<MinMax2, MinMax1, Mapper2to1>>> {
+        let concrete = MinMax2 {
+            user_input: user_input.clone(),
+        };
+        let abstractt = MinMax1 { user_input };
+        let mapper = Mapper2to1 {
+            abstract_model: abstractt,
+        };
+        let refinement_model = RefinementModel::new(concrete, mapper);
+        let checker = refinement_model
+            .checker()
+            .threads(num_cpus::get())
+            .serve("127.0.0.1:3000");
+
+        checker
+    }
 }
 
 fn main() -> Result<(), pico_args::Error> {
@@ -669,6 +720,18 @@ fn main() -> Result<(), pico_args::Error> {
             println!("Checking refinement from MinMax2 to MinMax1...");
             let checker = two_refine_one::refinement_checker(user_input).join();
             println!("Finish. State count: {}", checker.state_count());
+        }
+        Some("12-serve") => {
+            println!(
+                "Checking refinement from MinMax1 to MinMax2. Serving on: http://127.0.0.1:3000"
+            );
+            one_refine_two::refinement_serve(user_input);
+        }
+        Some("21-serve") => {
+            println!(
+                "Checking refinement from MinMax2 to MinMax1. Serving on: http://127.0.0.1:3000"
+            );
+            two_refine_one::refinement_serve(user_input);
         }
         _ => {
             println!("USAGE:");

--- a/examples/min_max.rs
+++ b/examples/min_max.rs
@@ -1,0 +1,681 @@
+//! This file is the MinMax example of Lamport's paper [Auxiliary Variables in TLA+](https://lamport.azurewebsites.net/pubs/auxiliary.pdf) which discusses refinement mappings and auxiliary variables in TLA+.
+//!
+//! # MinMax
+//! A user presents a server with a sequence of integer inputs.
+//! The server responds to each input value *i* with one of the following outputs:
+//! *Hi* if *i* is the largest number input so far,
+//! *Lo* if it’s the smallest number input so far,
+//! *Both* if it’s both,
+//! and *None* if it’s neither.
+//! We declare *Hi* , *Lo*, *Both*, and *None* in a constants statement. They are assumed not to be integers.
+//!
+//! ## MinMax1
+//! Our first specification appears in a module named MinMax 1.
+//! It describes the interaction of the user and the server with two variables: a variable x to hold an input or a response, and a variable turn that indicates whether it’s the user’s turn to input a value or the server’s turn to respond.
+//! The specification also uses a variable y to hold the set of values input so far.
+//! ```tla+
+//!
+//! ------------------------------- MODULE MinMax1 ------------------------------
+//! (***************************************************************************)
+//! (* This module and modules MinMax2 and MinMax2H are used as examples in    *)
+//! (* Sections 1 and 2 of the paper "Auxiliary Variables in TLA+".            *)
+//! (*                                                                         *)
+//! (* This module specifies a tiny system in which a user presents a server   *)
+//! (* with a sequence of integer inputs, and the server responds to each      *)
+//! (* input value i with with one of the following outputs: Hi if i is the    *)
+//! (* largest number input so far, Lo if it's the smallest number input so    *)
+//! (* far, Both if it's both, and None if it's neither.                       *)
+//! (*                                                                         *)
+//! (* The module is part of an example illustrating the use of a history      *)
+//! (* variable.  The example includes this module, module MinMax2, and module *)
+//! (* MinMax2H which adds a history variable to the specification of MinMax2  *)
+//! (* and shows that the resulting specification implements implements the    *)
+//! (* specification of the current module under a suitable refinement         *)
+//! (* mapping.                                                                *)
+//! (***************************************************************************)
+//! EXTENDS Integers
+//!
+//! (***************************************************************************)
+//! (* We define setMax(S) and setMin(S) to be largest and smallest value in a *)
+//! (* nonempty finite set S of integers.                                      *)
+//! (***************************************************************************)
+//! setMax(S) == CHOOSE t \in S : \A s \in S : t >= s
+//! setMin(S) == CHOOSE t \in S : \A s \in S : t =< s
+//!
+//! (***************************************************************************)
+//! (* The possible values that can be returned by the system are declared to  *)
+//! (* be constants, which we assume are not integers.                         *)
+//! (***************************************************************************)
+//! CONSTANTS Lo, Hi, Both, None
+//! ASSUME {Lo, Hi, Both, None} \cap Int = { }
+//!
+//! (***************************************************************************)
+//! (* The the value of the variable x is the value input by the user or the   *)
+//! (* value output by the system, the variable `turn' indicating which.  The  *)
+//! (* variable y holds the set of all values input thus far.  We consider x   *)
+//! (* and `turn' to be externally visible and y to be internal.               *)
+//! (***************************************************************************)
+//! VARIABLES x, turn, y
+//! vars == <<x, turn, y>>
+//!
+//! (***************************************************************************)
+//! (* The initial predicate Init:                                             *)
+//! (***************************************************************************)
+//! Init ==  /\ x = None
+//!          /\ turn = "input"
+//!          /\ y = {}
+//!
+//! (***************************************************************************)
+//! (* The user's input action:                                                *)
+//! (***************************************************************************)
+//! InputNum ==  /\ turn = "input"
+//!              /\ turn' = "output"
+//!              /\ x' \in Int
+//!              /\ y' = y
+//!
+//! (***************************************************************************)
+//! (* The systems response action:                                            *)
+//! (***************************************************************************)
+//! Respond == /\ turn = "output"
+//!            /\ turn' = "input"
+//!            /\ y' = y \cup {x}
+//!            /\ x' = IF x = setMax(y') THEN IF x = setMin(y') THEN Both ELSE Hi  
+//!                                      ELSE IF x = setMin(y') THEN Lo   ELSE None
+//!
+//! (***************************************************************************)
+//! (* The next-state action:                                                  *)
+//! (***************************************************************************)  
+//! Next == InputNum \/ Respond
+//!
+//! (***************************************************************************)
+//! (* The specification, which is a safety property (it asserts no liveness   *)
+//! (* condition).                                                             *)
+//! (***************************************************************************)
+//! Spec == Init /\ [][Next]_vars
+//! -----------------------------------------------------------------------------
+//! (***************************************************************************)
+//! (* Below, we check that specification Spec implements specification Spec   *)
+//! (* of module MinMax2 under a suitable refinement mapping.  The following   *)
+//! (* definitions of Infinity and MinusInfinity are copied from module        *)
+//! (* MinMax2.                                                                *)
+//! (***************************************************************************)
+//! Infinity      == CHOOSE n : n \notin Int
+//! MinusInfinity == CHOOSE n : n \notin (Int \cup {Infinity})
+//!
+//! M == INSTANCE MinMax2
+//!         WITH min <- IF y = {} THEN Infinity      ELSE setMin(y),
+//!              max <- IF y = {} THEN MinusInfinity ELSE setMax(y)
+//!
+//! (***************************************************************************)
+//! (* The following theorem asserts that Spec implements the specification    *)
+//! (* Spec of module MinMax2 under the refinement mapping defined by the      *)
+//! (* INSTANCE statement.  The theorem can be checked with TLC using a model  *)
+//! (* having M!Spec as the temporal property to be checked.                   *)
+//! (***************************************************************************)
+//! THEOREM Spec => M!Spec
+//! =============================================================================
+//!
+//! ```
+//!
+//!
+//! ## MinMax2
+//! The specification of our system in module MinMax 1 uses the variable y to remember the set of all values that the user has input.
+//! Module MinMax 2 specifies the same user/server interaction that remembers only the smallest and largest values input so far,
+//! using the variables min and max.
+//!
+//! ```tla+
+//! ------------------------------ MODULE MinMax2 -------------------------------
+//! (***************************************************************************)
+//! (* This module specifies a system with the same interaction between a user *)
+//! (* and a server as the one in module MinMax1, but instead of remembering   *)
+//! (* the entire set of inputs, it uses two variables min and max to keep the *)
+//! (* largest and smallest values input thus far.  Initially min equals       *)
+//! (* Infinity and max equals MinusInfinity, where Infinity and MinusInfinity *)
+//! (* are two values that are considered greater than and less than any       *)
+//! (* integer, respectively.                                                  *)
+//! (***************************************************************************)
+//! EXTENDS Integers, Sequences
+//!
+//! CONSTANTS Lo, Hi, Both, None
+//! ASSUME {Lo, Hi, Both, None} \cap Int = { }
+//!
+//! Infinity      == CHOOSE n : n \notin Int
+//! MinusInfinity == CHOOSE n : n \notin (Int \cup {Infinity})
+//!
+//! (***************************************************************************)
+//! (* The operators IsLeq and IsGeq extend =< and >=, respectively, to have   *)
+//! (* the correct meaning when Infinity or MinusInfinity is one of the        *)
+//! (* arguments.                                                              *)
+//! (***************************************************************************)
+//! IsLeq(i, j) == (j = Infinity) \/ (i =< j)
+//! IsGeq(i, j) == (j = MinusInfinity) \/ (i >= j)
+//!
+//! (***************************************************************************)
+//! (* The rest of the specification is straightforward.                       *)
+//! (***************************************************************************)
+//! VARIABLES x, turn, min, max
+//! vars == <<x, turn, min, max>>
+//!
+//! Init ==  /\ x = None
+//!          /\ turn = "input"
+//!          /\ min = Infinity
+//!          /\ max = MinusInfinity
+//!
+//! InputNum ==  /\ turn = "input"
+//!              /\ turn' = "output"
+//!              /\ x' \in Int
+//!              /\ UNCHANGED <<min, max>>
+//!
+//! Respond  ==  /\ turn = "output"
+//!              /\ turn' = "input"
+//!              /\ min' = IF IsLeq(x, min) THEN x ELSE min
+//!              /\ max' = IF IsGeq(x, max) THEN x ELSE max
+//!              /\ x' = IF x = max' THEN IF x = min' THEN Both ELSE Hi  
+//!                                  ELSE IF x = min' THEN Lo   ELSE None
+//!           
+//! Next == InputNum \/ Respond
+//!
+//! Spec == Init /\ [][Next]_vars
+//! =============================================================================
+//!
+//! ```
+//!
+
+use stateright::Checker;
+
+mod min_max1 {
+    use stateright::Model;
+
+    use crate::min_max2;
+
+    #[derive(Clone, Hash, PartialEq)]
+    pub(crate) enum Turn {
+        Input,
+        Output,
+    }
+
+    #[derive(Clone, Hash, PartialEq)]
+    pub(crate) enum Response {
+        Lo,
+        Hi,
+        Both,
+        None,
+    }
+
+    #[derive(Clone, Hash, PartialEq)]
+    pub(crate) enum XType {
+        Input(usize),
+        Output(Response),
+    }
+
+    #[derive(Clone, Hash, PartialEq)]
+    pub(crate) struct MinMax1State {
+        pub x: Option<XType>,
+        pub turn: Turn,
+        pub y: Vec<usize>,
+
+        pub idx: usize,
+    }
+
+    #[derive(Clone, PartialEq)]
+    pub(crate) enum MinMax1Action {
+        InputNum,
+        Respond,
+    }
+
+    #[derive(Debug, Clone, Hash, PartialEq)]
+    pub(crate) struct MinMax1 {
+        pub user_input: Vec<usize>,
+    }
+
+    impl Model for MinMax1 {
+        type State = MinMax1State;
+
+        type Action = MinMax1Action;
+
+        fn init_states(&self) -> Vec<Self::State> {
+            vec![MinMax1State {
+                x: None,
+                turn: Turn::Input,
+                y: vec![],
+                idx: 0,
+            }]
+        }
+
+        fn actions(&self, state: &Self::State, actions: &mut Vec<Self::Action>) {
+            match state.turn {
+                Turn::Input => actions.push(MinMax1Action::InputNum),
+                Turn::Output => actions.push(MinMax1Action::Respond),
+            }
+        }
+
+        fn next_state(
+            &self,
+            last_state: &Self::State,
+            action: Self::Action,
+        ) -> Option<Self::State> {
+            if last_state.idx == self.user_input.len() {
+                return None;
+            }
+
+            let mut state = last_state.clone();
+
+            match action {
+                MinMax1Action::InputNum => {
+                    // turn' = output
+                    state.turn = Turn::Output;
+                    // x' \in Int
+                    state.x = Some(XType::Input(self.user_input[last_state.idx]));
+                    state.idx += 1;
+                    // y' = y. keep y unchanged.
+                }
+                MinMax1Action::Respond => {
+                    // turn' = "input"
+                    state.turn = Turn::Input;
+                    // y' = y \union {x}
+                    if let Some(XType::Input(x)) = last_state.x {
+                        state.y.push(x);
+
+                        // x' = IF x = Max(y')
+                        //      THEN IF x = Min(y') THEN Both ELSE Hi
+                        //      ELSE IF x = Min(y') THEN Lo ELSE None
+                        let y_max = *state.y.iter().max().unwrap();
+                        let y_min = *state.y.iter().min().unwrap();
+                        if x == y_max && x == y_min {
+                            state.x = Some(XType::Output(Response::Both))
+                        } else if x == y_max {
+                            state.x = Some(XType::Output(Response::Hi))
+                        } else if x == y_min {
+                            state.x = Some(XType::Output(Response::Lo))
+                        } else {
+                            state.x = Some(XType::Output(Response::None))
+                        }
+                    }
+                }
+            }
+
+            Some(state)
+        }
+    }
+
+    impl From<min_max2::Response> for Response {
+        fn from(value: min_max2::Response) -> Self {
+            match value {
+                min_max2::Response::Lo => Self::Lo,
+                min_max2::Response::Hi => Self::Hi,
+                min_max2::Response::Both => Self::Both,
+                min_max2::Response::None => Self::None,
+            }
+        }
+    }
+
+    impl From<min_max2::XType> for XType {
+        fn from(value: min_max2::XType) -> Self {
+            match value {
+                min_max2::XType::Input(x) => Self::Input(x),
+                min_max2::XType::Output(response) => Self::Output(response.into()),
+            }
+        }
+    }
+
+    impl From<min_max2::Turn> for Turn {
+        fn from(value: min_max2::Turn) -> Self {
+            match value {
+                min_max2::Turn::Input => Self::Input,
+                min_max2::Turn::Output => Self::Output,
+            }
+        }
+    }
+}
+
+mod min_max2 {
+    use std::{
+        cmp::{max, min},
+        usize,
+    };
+
+    use stateright::Model;
+
+    use crate::min_max1;
+
+    #[derive(Clone, Hash, PartialEq)]
+    pub(crate) enum Turn {
+        Input,
+        Output,
+    }
+
+    #[derive(Clone, Hash, PartialEq)]
+    pub(crate) enum Response {
+        Lo,
+        Hi,
+        Both,
+        None,
+    }
+
+    #[derive(Clone, Hash, PartialEq)]
+    pub(crate) enum XType {
+        Input(usize),
+        Output(Response),
+    }
+
+    #[derive(Clone, Hash, PartialEq)]
+    pub(crate) struct MinMax2State {
+        pub x: Option<XType>,
+        pub turn: Turn,
+        pub min: usize,
+        pub max: usize,
+
+        pub idx: usize,
+    }
+
+    #[derive(Clone, PartialEq)]
+    pub(crate) enum MinMax2Action {
+        InputNum,
+        Respond,
+    }
+
+    #[derive(Debug, Clone, Hash, PartialEq)]
+    pub(crate) struct MinMax2 {
+        pub user_input: Vec<usize>,
+    }
+
+    impl Model for MinMax2 {
+        type State = MinMax2State;
+
+        type Action = MinMax2Action;
+
+        fn init_states(&self) -> Vec<Self::State> {
+            vec![MinMax2State {
+                x: None,
+                turn: Turn::Input,
+                min: usize::MAX, // set initial min as MAX
+                max: usize::MIN, // set initial max as MIN
+                idx: 0,
+            }]
+        }
+
+        fn actions(&self, state: &Self::State, actions: &mut Vec<Self::Action>) {
+            match state.turn {
+                Turn::Input => actions.push(MinMax2Action::InputNum),
+                Turn::Output => actions.push(MinMax2Action::Respond),
+            }
+        }
+
+        fn next_state(
+            &self,
+            last_state: &Self::State,
+            action: Self::Action,
+        ) -> Option<Self::State> {
+            if last_state.idx == self.user_input.len() {
+                return None;
+            }
+
+            let mut state = last_state.clone();
+
+            match action {
+                MinMax2Action::InputNum => {
+                    // turn' = "output"
+                    state.turn = Turn::Output;
+                    // x' \in Int
+                    state.x = Some(XType::Input(self.user_input[last_state.idx]));
+                    state.idx += 1;
+                    // UNCHANGED <<min, max>>
+                }
+                MinMax2Action::Respond => {
+                    // turn' = "input"
+                    state.turn = Turn::Input;
+                    if let Some(XType::Input(x)) = last_state.x {
+                        // min' = IF IsLeq(x, min) THEN x ELSE min
+                        state.min = min(x, last_state.min);
+                        // max' = IF IsGeq(x, max) THEN x ELSE max
+                        state.max = max(x, last_state.max);
+                        // x' = IF x = max' THEN IF x = min' THEN Both ELSE Hi ELSE IF x = min' THEN Lo ELSE None
+                        let resp = if x == state.max && x == state.min {
+                            Response::Both
+                        } else if x == state.max {
+                            Response::Hi
+                        } else if x == state.min {
+                            Response::Lo
+                        } else {
+                            Response::None
+                        };
+                        state.x = Some(XType::Output(resp));
+                    }
+                }
+            }
+
+            Some(state)
+        }
+    }
+
+    impl From<min_max1::Response> for Response {
+        fn from(value: min_max1::Response) -> Self {
+            match value {
+                min_max1::Response::Lo => Self::Lo,
+                min_max1::Response::Hi => Self::Hi,
+                min_max1::Response::Both => Self::Both,
+                min_max1::Response::None => Self::None,
+            }
+        }
+    }
+
+    impl From<min_max1::XType> for XType {
+        fn from(value: min_max1::XType) -> Self {
+            match value {
+                min_max1::XType::Input(x) => Self::Input(x),
+                min_max1::XType::Output(response) => Self::Output(response.into()),
+            }
+        }
+    }
+
+    impl From<min_max1::Turn> for Turn {
+        fn from(value: min_max1::Turn) -> Self {
+            match value {
+                min_max1::Turn::Input => Self::Input,
+                min_max1::Turn::Output => Self::Output,
+            }
+        }
+    }
+}
+
+mod one_refine_two {
+    // try to build refinement mapping from MinMax1 to MinMax2.
+    // That is, we treat MinMax1 as concrete implementation and MinMax2 as abstract model
+
+    use stateright::{
+        refinement_mapping::{RefinementMapping, RefinementModel},
+        Checker, Model,
+    };
+
+    use crate::{min_max1::*, min_max2::*};
+
+    #[derive(Debug, Hash, Clone, PartialEq)]
+    pub(crate) struct Mapper1to2 {
+        abstract_model: MinMax2,
+    }
+
+    /// We don't need auxiliary states to build MinMax1 to MinMax2
+    /// M == INSTANCE MinMax2
+    ///     WITH min <- IF y = {} THEN Infinity ELSE setMin(y),
+    ///         max <- IF y = {} THEN MinusInfinity ELSE setMax(y).
+    impl RefinementMapping<MinMax1, MinMax2> for Mapper1to2 {
+        type AuxState = ();
+
+        fn abstract_model(&self) -> &MinMax2 {
+            &self.abstract_model
+        }
+
+        fn init_aux_state(
+            &self,
+            _concrete: &<MinMax1 as stateright::Model>::State,
+        ) -> Self::AuxState {
+            ()
+        }
+
+        fn advance_aux_state(
+            &self,
+            _last_concrete: &<MinMax1 as stateright::Model>::State,
+            _last_aux: &Self::AuxState,
+            _action: &<MinMax1 as stateright::Model>::Action,
+            _next_concrete: &<MinMax1 as stateright::Model>::State,
+        ) -> Self::AuxState {
+            ()
+        }
+
+        fn map_state(
+            &self,
+            concrete: &<MinMax1 as stateright::Model>::State,
+            _aux: &Self::AuxState,
+        ) -> <MinMax2 as stateright::Model>::State {
+            MinMax2State {
+                x: concrete.x.clone().map(|x| x.into()),
+                turn: concrete.turn.clone().into(),
+                min: *concrete.y.iter().min().unwrap_or(&usize::MAX),
+                max: *concrete.y.iter().max().unwrap_or(&usize::MIN),
+                idx: concrete.idx,
+            }
+        }
+    }
+
+    pub fn refinement_checker(
+        user_input: Vec<usize>,
+    ) -> impl Checker<RefinementModel<MinMax1, MinMax2, Mapper1to2>> {
+        let concrete = MinMax1 {
+            user_input: user_input.clone(),
+        };
+        let abstractt = MinMax2 { user_input };
+        let mapper = Mapper1to2 {
+            abstract_model: abstractt,
+        };
+        let refinement_model = RefinementModel::new(concrete, mapper);
+        let checker = refinement_model
+            .checker()
+            .threads(num_cpus::get())
+            .spawn_dfs();
+
+        checker
+    }
+}
+
+mod two_refine_one {
+    use stateright::{
+        refinement_mapping::{RefinementMapping, RefinementModel},
+        Checker, Model,
+    };
+
+    use crate::{
+        min_max1::{MinMax1, MinMax1State},
+        min_max2::{MinMax2, MinMax2Action, XType},
+    };
+
+    #[derive(Debug, Hash, Clone, PartialEq)]
+    pub(crate) struct Mapper2to1 {
+        abstract_model: MinMax1,
+    }
+
+    /// we need auxiliary state to have refinement mapping from MinMax2 to MinMax1,
+    /// because MinMax2 only stores the min and max, while MinMax1 stores all the history.
+    /// so, our auxiliary state for MinMax2 is basically a history that store all the values MinMax2 has seen so far.
+    ///
+    /// M == INSTANCE MinMax1 WITH y <- h
+
+    type History = Vec<usize>;
+
+    impl RefinementMapping<MinMax2, MinMax1> for Mapper2to1 {
+        type AuxState = History;
+
+        fn abstract_model(&self) -> &MinMax1 {
+            &self.abstract_model
+        }
+
+        fn init_aux_state(
+            &self,
+            _concrete: &<MinMax2 as stateright::Model>::State,
+        ) -> Self::AuxState {
+            // initally, the history is an empty vec
+            vec![]
+        }
+
+        fn advance_aux_state(
+            &self,
+            _last_concrete: &<MinMax2 as stateright::Model>::State,
+            last_aux: &Self::AuxState,
+            action: &<MinMax2 as stateright::Model>::Action,
+            next_concrete: &<MinMax2 as stateright::Model>::State,
+        ) -> Self::AuxState {
+            let mut new_aux = last_aux.clone();
+
+            match action {
+                MinMax2Action::InputNum => {
+                    // the newly inserted number is the next_concrete.x
+                    if let Some(XType::Input(n)) = next_concrete.x {
+                        new_aux.push(n);
+                    } else {
+                        panic!("State transition doesn't match with action. Action is InputNum, but next_state.x is not XType::Input.")
+                    }
+                }
+                MinMax2Action::Respond => {} // no update is needed if action is Respond
+            }
+
+            new_aux
+        }
+
+        fn map_state(
+            &self,
+            concrete: &<MinMax2 as stateright::Model>::State,
+            aux: &Self::AuxState,
+        ) -> <MinMax1 as stateright::Model>::State {
+            MinMax1State {
+                x: concrete.x.clone().map(|x| x.into()),
+                turn: concrete.turn.clone().into(),
+                y: aux.clone(),
+                idx: concrete.idx,
+            }
+        }
+    }
+
+    pub fn refinement_checker(
+        user_input: Vec<usize>,
+    ) -> impl Checker<RefinementModel<MinMax2, MinMax1, Mapper2to1>> {
+        let concrete = MinMax2 {
+            user_input: user_input.clone(),
+        };
+        let abstractt = MinMax1 { user_input };
+        let mapper = Mapper2to1 {
+            abstract_model: abstractt,
+        };
+        let refinement_model = RefinementModel::new(concrete, mapper);
+        let checker = refinement_model
+            .checker()
+            .threads(num_cpus::get())
+            .spawn_dfs();
+
+        checker
+    }
+}
+
+fn main() -> Result<(), pico_args::Error> {
+    env_logger::init_from_env(env_logger::Env::default().default_filter_or("info")); // `RUST_LOG=${LEVEL}` env variable to override
+
+    let mut args = pico_args::Arguments::from_env();
+    let user_input = vec![4, 1, 2, 3];
+    match args.subcommand()?.as_deref() {
+        Some("12") => {
+            println!("Checking refinement from MinMax1 to MinMax2...");
+            let checker = one_refine_two::refinement_checker(user_input).join();
+            println!("Finish. State count: {}", checker.state_count());
+        }
+        Some("21") => {
+            println!("Checking refinement from MinMax2 to MinMax1...");
+            let checker = two_refine_one::refinement_checker(user_input).join();
+            println!("Finish. State count: {}", checker.state_count());
+        }
+        _ => {
+            println!("USAGE:");
+            println!("  ./min_max 12");
+            println!("  ./min_max 21");
+        }
+    }
+
+    Ok(())
+}

--- a/examples/min_max.rs
+++ b/examples/min_max.rs
@@ -188,13 +188,13 @@ mod min_max1 {
 
     use crate::min_max2;
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) enum Turn {
         Input,
         Output,
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) enum Response {
         Lo,
         Hi,
@@ -202,13 +202,13 @@ mod min_max1 {
         None,
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) enum XType {
         Input(usize),
         Output(Response),
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) struct MinMax1State {
         pub x: Option<XType>,
         pub turn: Turn,
@@ -217,13 +217,13 @@ mod min_max1 {
         pub idx: usize,
     }
 
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub(crate) enum MinMax1Action {
         InputNum,
         Respond,
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) struct MinMax1 {
         pub user_input: Vec<usize>,
     }
@@ -338,13 +338,13 @@ mod min_max2 {
 
     use crate::min_max1;
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) enum Turn {
         Input,
         Output,
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) enum Response {
         Lo,
         Hi,
@@ -352,13 +352,13 @@ mod min_max2 {
         None,
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) enum XType {
         Input(usize),
         Output(Response),
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) struct MinMax2State {
         pub x: Option<XType>,
         pub turn: Turn,
@@ -368,13 +368,13 @@ mod min_max2 {
         pub idx: usize,
     }
 
-    #[derive(Debug, Clone, PartialEq)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub(crate) enum MinMax2Action {
         InputNum,
         Respond,
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) struct MinMax2 {
         pub user_input: Vec<usize>,
     }
@@ -489,7 +489,7 @@ mod one_refine_two {
 
     use crate::{min_max1::*, min_max2::*};
 
-    #[derive(Debug, Hash, Clone, PartialEq)]
+    #[derive(Debug, Hash, Clone, PartialEq, Eq)]
     pub(crate) struct Mapper1to2 {
         abstract_model: MinMax2,
     }
@@ -500,6 +500,7 @@ mod one_refine_two {
     ///         max <- IF y = {} THEN MinusInfinity ELSE setMax(y).
     impl RefinementMapping<MinMax1, MinMax2> for Mapper1to2 {
         type AuxState = ();
+        type Observable = MinMax2State;
 
         fn abstract_model(&self) -> &MinMax2 {
             &self.abstract_model
@@ -522,7 +523,7 @@ mod one_refine_two {
             ()
         }
 
-        fn map_state(
+        fn refinement_map(
             &self,
             concrete: &<MinMax1 as stateright::Model>::State,
             _aux: &Self::AuxState,
@@ -534,6 +535,10 @@ mod one_refine_two {
                 max: *concrete.y.iter().max().unwrap_or(&usize::MIN),
                 idx: concrete.idx,
             }
+        }
+
+        fn observe(&self, a: &MinMax2State) -> MinMax2State {
+            a.clone()
         }
     }
 
@@ -587,7 +592,7 @@ mod two_refine_one {
         min_max2::{MinMax2, MinMax2Action, XType},
     };
 
-    #[derive(Debug, Hash, Clone, PartialEq)]
+    #[derive(Debug, Hash, Clone, PartialEq, Eq)]
     pub(crate) struct Mapper2to1 {
         abstract_model: MinMax1,
     }
@@ -602,6 +607,7 @@ mod two_refine_one {
 
     impl RefinementMapping<MinMax2, MinMax1> for Mapper2to1 {
         type AuxState = History;
+        type Observable = MinMax1State;
 
         fn abstract_model(&self) -> &MinMax1 {
             &self.abstract_model
@@ -652,7 +658,7 @@ mod two_refine_one {
             new_aux
         }
 
-        fn map_state(
+        fn refinement_map(
             &self,
             concrete: &<MinMax2 as stateright::Model>::State,
             aux: &Self::AuxState,
@@ -663,6 +669,10 @@ mod two_refine_one {
                 y: aux.clone(),
                 idx: concrete.idx,
             }
+        }
+
+        fn observe(&self, a: &MinMax1State) -> MinMax1State {
+            a.clone()
         }
     }
 

--- a/examples/multithreaded-counter.rs
+++ b/examples/multithreaded-counter.rs
@@ -1,0 +1,690 @@
+//! This file contains an example of refinement mappings from this [blog post](https://www.hillelwayne.com/post/refinement/) by Hillel Wayne.
+//!
+//! In this file, we will have an abstract model for a multithreaded counter, a bad implementation that DOES NOT correctly implement the counter, and a good implementation which correctly implements the counter. For more details, please check the above nice blog post.
+//!
+//! We will show that the bad implementation will fail the refinement checking, while the good implementation will pass. Interestingly, we'll also see that the good implementation actually refines the bad implementation.
+//!
+//! The TLA+ specification for the abstract model:
+//! ```tla+
+//! ---- MODULE abstract ----
+//! EXTENDS Integers, Sequences
+//!
+//! VARIABLES pc, counter
+//! vars == <<pc, counter>>
+//!
+//! \* Two threads
+//! Threads == 1..2
+//!
+//! \* State transition action
+//! Trans(thread, from, to) ==
+//!   /\ pc[thread] = from
+//!   /\ pc' = [pc EXCEPT ![thread] = to]
+//!
+//! \* Both threads start in the `start` state
+//! Init ==
+//!   /\ pc = [t \in Threads |-> "start"]
+//!   /\ counter = 0
+//!
+//! Next ==
+//!   \* Pick one thread
+//!   \/ \E t \in Threads:
+//!      \* Move it to `done`
+//!      /\ Trans(t, "start", "done")
+//!      \* Increment counter
+//!      /\ counter' = counter + 1
+//!
+//! Spec == Init /\ [][Next]_vars
+//!
+//! ====
+//! ```
+//!
+//!
+//!
+//! The TLA+ for the bad implementation:
+//! ```tla+
+//! ---- MODULE bad ----
+//! EXTENDS Integers, Sequences
+//!
+//! VARIABLES pc, counter, tmp
+//! vars == <<pc, counter, tmp>>
+//!
+//! Threads == 1..2
+//!
+//! States == {"start", "inc", "done"}
+//!
+//! Trans(thread, from, to) ==
+//!   /\ pc[thread] = from
+//!   /\ pc' = [pc EXCEPT ![thread] = to]
+//!
+//! Init ==
+//!   /\ pc = [t \in Threads |-> "start"]
+//!   /\ counter = 0
+//!   /\ tmp = [t \in Threads |-> 0]
+//!
+//! GetCounter(t) ==
+//!   /\ tmp' = [tmp EXCEPT ![t] = counter]
+//!   /\ UNCHANGED counter
+//!
+//! IncCounter(t) ==
+//!   /\ counter' = tmp[t] + 1
+//!   /\ UNCHANGED tmp
+//!
+//! Next ==
+//!   \/ \E t \in Threads:
+//!     \* Step to get the counter value
+//!     \/ /\ Trans(t, "start", "inc")
+//!        /\ GetCounter(t)
+//!     \* Step to increment the counter
+//!     \/ /\ Trans(t, "inc", "done")
+//!        /\ IncCounter(t)
+//!
+//! Spec == Init /\ [][Next]_vars
+//! ====
+//! ```
+//!
+//!
+//! The TLA+ for the good implementation:
+//! ```tla+
+//! ---- MODULE good ----
+//! EXTENDS Integers, Sequences
+//!
+//! VARIABLES pc, counter, tmp, lock
+//! vars == <<pc, counter, tmp, lock>>
+//!
+//! Threads == 1..2
+//!
+//! States == {"start", "inc", "done"}
+//!
+//! Trans(thread, from, to) ==
+//!   /\ pc[thread] = from
+//!   /\ pc' = [pc EXCEPT ![thread] = to]
+//!
+//! Init ==
+//!   /\ pc = [t \in Threads |-> "start"]
+//!   /\ counter = 0
+//!   /\ tmp = <<0, 0>>
+//!   /\ lock = 0
+//!
+//! AcquireLock(t) ==
+//!   /\ lock = 0
+//!   /\ lock' = t
+//!
+//! ReleaseLock(t) ==
+//!   /\ lock = t
+//!   /\ lock' = 0
+//!
+//! GetCounter(t) ==
+//!   /\ tmp' = [tmp EXCEPT ![t] = counter]
+//!   /\ UNCHANGED counter
+//!
+//! IncCounter(t) ==
+//!   /\ counter' = tmp[t] + 1
+//!   /\ UNCHANGED tmp
+//!
+//! Next ==
+//!   \/ \E t \in Threads:
+//!     \/ /\ Trans(t, "start", "inc")
+//!        /\ GetCounter(t)
+//!        /\ AcquireLock(t)
+//!     \/ /\ Trans(t, "inc", "done")
+//!        /\ IncCounter(t)
+//!        /\ ReleaseLock(t)
+//!
+//! Spec == Init /\ [][Next]_vars
+//!
+//! Mapping ==
+//!   INSTANCE abstract WITH
+//!     counter <- counter,
+//!     pc <- [t \in Threads |->
+//!       IF pc[t] = "inc" THEN "start"
+//!       ELSE pc[t]
+//!       ]
+//!
+//! Refinement == Mapping!Spec
+//!
+//! ====
+//! ```
+//!
+
+mod abstract_model {
+    use stateright::Model;
+
+    #[derive(Debug, Clone, Hash, PartialEq)]
+    pub(crate) enum CounterAction {
+        Trans(usize), // Transfer the TransitionState of the thread with usize index.
+    }
+
+    #[derive(Debug, Clone, Hash, PartialEq)]
+    pub(crate) enum TransitionState {
+        Start,
+        Done,
+    }
+
+    #[derive(Debug, Clone, Hash, PartialEq)]
+    pub(crate) struct CounterState {
+        pub pc: Vec<TransitionState>,
+        pub counter: usize,
+    }
+
+    #[derive(Debug, Clone, Hash, PartialEq)]
+    pub(crate) struct Counter {
+        pub threads: usize,
+    }
+
+    impl Model for Counter {
+        type State = CounterState;
+
+        type Action = CounterAction;
+
+        fn init_states(&self) -> Vec<Self::State> {
+            vec![CounterState {
+                pc: vec![TransitionState::Start; self.threads],
+                counter: 0,
+            }]
+        }
+
+        fn actions(&self, state: &Self::State, actions: &mut Vec<Self::Action>) {
+            state
+                .pc
+                .iter()
+                .enumerate()
+                .for_each(|(idx, transition_state)| {
+                    // we can transfer all the threads whose transition states are not Done.
+                    if *transition_state != TransitionState::Done {
+                        actions.push(CounterAction::Trans(idx));
+                    }
+                });
+        }
+
+        fn next_state(
+            &self,
+            last_state: &Self::State,
+            action: Self::Action,
+        ) -> Option<Self::State> {
+            let mut state = last_state.clone();
+            let CounterAction::Trans(idx) = action;
+
+            if last_state.pc[idx] == TransitionState::Done {
+                panic!(
+                    "Panic! Trying to transfer thread {}, but its state is already Done.",
+                    idx
+                );
+            }
+
+            // turn the idx thread into Done, and increment the counter.
+            state.pc[idx] = TransitionState::Done;
+            state.counter += 1;
+
+            Some(state)
+        }
+    }
+}
+
+mod bad_impl {
+    use stateright::Model;
+
+    #[derive(Debug, Clone, Hash, PartialEq)]
+    pub(crate) enum CounterAction {
+        GetCounter(usize), // get the global counter to update the thread's local counter
+        IncCounter(usize), // update the global counter based on the thread's local counter
+    }
+
+    #[derive(Debug, Clone, Hash, PartialEq)]
+    pub(crate) enum TransitionState {
+        Start,
+        Inc,
+        Done,
+    }
+
+    #[derive(Debug, Clone, Hash, PartialEq)]
+    pub(crate) struct CounterState {
+        pub pc: Vec<TransitionState>,
+        pub counter: usize,
+        pub tmp: Vec<usize>, // local counter for each thread
+    }
+
+    #[derive(Debug, Clone, Hash, PartialEq)]
+    pub(crate) struct Counter {
+        pub threads: usize,
+    }
+
+    impl Model for Counter {
+        type State = CounterState;
+
+        type Action = CounterAction;
+
+        fn init_states(&self) -> Vec<Self::State> {
+            vec![CounterState {
+                pc: vec![TransitionState::Start; self.threads],
+                counter: 0,
+                tmp: vec![0; self.threads],
+            }]
+        }
+
+        fn actions(&self, state: &Self::State, actions: &mut Vec<Self::Action>) {
+            state.pc.iter().enumerate().for_each(
+                |(idx, transition_state)| match transition_state {
+                    // if the thread is Start, it can perform GetCounter.
+                    TransitionState::Start => actions.push(CounterAction::GetCounter(idx)),
+                    // if the thread is Inc, it can perform IncCounter.
+                    TransitionState::Inc => actions.push(CounterAction::IncCounter(idx)),
+                    // if the thread is Done, it can do nothing.
+                    TransitionState::Done => (),
+                },
+            );
+        }
+
+        fn next_state(
+            &self,
+            last_state: &Self::State,
+            action: Self::Action,
+        ) -> Option<Self::State> {
+            let mut state = last_state.clone();
+
+            match action {
+                CounterAction::GetCounter(idx) => {
+                    // transfer the thread state into Inc
+                    state.pc[idx] = TransitionState::Inc;
+                    // update my local counter as the global counter
+                    state.tmp[idx] = last_state.counter;
+                }
+                CounterAction::IncCounter(idx) => {
+                    // transfer the thread state into Done
+                    state.pc[idx] = TransitionState::Done;
+                    // update the global counter based on my local counter
+                    state.counter = last_state.tmp[idx] + 1;
+                }
+            }
+
+            Some(state)
+        }
+    }
+}
+
+mod good_impl {
+    use std::usize;
+
+    use stateright::Model;
+
+    #[derive(Debug, Clone, Hash, PartialEq)]
+    pub(crate) enum CounterAction {
+        LockAndGetCounter(usize),
+        ReleaseAndIncCounter(usize),
+    }
+
+    #[derive(Debug, Clone, Hash, PartialEq)]
+    pub(crate) enum TransitionState {
+        Start,
+        Inc,
+        Done,
+    }
+
+    #[derive(Debug, Clone, Hash, PartialEq)]
+    pub(crate) struct CounterState {
+        pub pc: Vec<TransitionState>,
+        pub counter: usize,
+        pub tmp: Vec<usize>,
+        pub lock: usize, // indicate which thread is holding the lock. if it's free, set the value to usize::MAX.
+    }
+
+    #[derive(Debug, Clone, Hash, PartialEq)]
+    pub(crate) struct Counter {
+        pub threads: usize,
+    }
+
+    impl Model for Counter {
+        type State = CounterState;
+
+        type Action = CounterAction;
+
+        fn init_states(&self) -> Vec<Self::State> {
+            vec![CounterState {
+                pc: vec![TransitionState::Start; self.threads],
+                counter: 0,
+                tmp: vec![0; self.threads],
+                lock: usize::MAX,
+            }]
+        }
+
+        fn actions(&self, state: &Self::State, actions: &mut Vec<Self::Action>) {
+            (0..self.threads).into_iter().for_each(|idx| {
+                // if transition state is Start and lock is MAX, we can perform LockAndGetCounter action
+                if state.pc[idx] == TransitionState::Start && state.lock == usize::MAX {
+                    actions.push(CounterAction::LockAndGetCounter(idx));
+                    return;
+                }
+                // if transition state is Inc and lock is me, we can perform ReleaseAndIncCounter action
+                if state.pc[idx] == TransitionState::Inc && state.lock == idx {
+                    actions.push(CounterAction::ReleaseAndIncCounter(idx));
+                    return;
+                }
+                // otherwise, no action can be performed
+            });
+        }
+
+        fn next_state(
+            &self,
+            last_state: &Self::State,
+            action: Self::Action,
+        ) -> Option<Self::State> {
+            let mut state = last_state.clone();
+
+            match action {
+                CounterAction::LockAndGetCounter(idx) => {
+                    // update transition state to Inc
+                    state.pc[idx] = TransitionState::Inc;
+                    // update local counter with the global counter
+                    state.tmp[idx] = last_state.counter;
+                    // acquire lock
+                    state.lock = idx;
+                }
+                CounterAction::ReleaseAndIncCounter(idx) => {
+                    // update transition state to Done
+                    state.pc[idx] = TransitionState::Done;
+                    // update global counter using local counter
+                    state.counter = last_state.tmp[idx] + 1;
+                    // releae lock
+                    state.lock = usize::MAX;
+                }
+            };
+
+            Some(state)
+        }
+    }
+}
+
+mod try_bad_refine_abstract {
+    use stateright::{
+        refinement_mapping::{RefinementMapping, RefinementModel},
+        Checker, Model,
+    };
+
+    use crate::{abstract_model, bad_impl};
+
+    #[derive(Debug, Hash, Clone, PartialEq)]
+    pub(crate) struct Bad2AbstractMapper {
+        abstract_model: abstract_model::Counter,
+    }
+
+    // no auxiliary state is needed.
+    // Mapping ==
+    //   INSTANCE abstract WITH
+    //     counter <- counter,
+    //     pc <- [t \in Threads |->
+    //       IF pc[t] = "inc" THEN "start"
+    //       ELSE pc[t]
+    //       ]
+    impl RefinementMapping<bad_impl::Counter, abstract_model::Counter> for Bad2AbstractMapper {
+        type AuxState = ();
+
+        fn abstract_model(&self) -> &abstract_model::Counter {
+            &self.abstract_model
+        }
+
+        fn init_aux_state(
+            &self,
+            _concrete: &<bad_impl::Counter as stateright::Model>::State,
+        ) -> Self::AuxState {
+            ()
+        }
+
+        fn advance_aux_state(
+            &self,
+            _last_concrete: &<bad_impl::Counter as stateright::Model>::State,
+            _last_aux: &Self::AuxState,
+            _action: &<bad_impl::Counter as stateright::Model>::Action,
+            _next_concrete: &<bad_impl::Counter as stateright::Model>::State,
+        ) -> Self::AuxState {
+            ()
+        }
+
+        fn map_state(
+            &self,
+            concrete: &<bad_impl::Counter as stateright::Model>::State,
+            _aux: &Self::AuxState,
+        ) -> <abstract_model::Counter as stateright::Model>::State {
+            abstract_model::CounterState {
+                pc: concrete
+                    .pc
+                    .iter()
+                    .map(|s| match s {
+                        bad_impl::TransitionState::Start => abstract_model::TransitionState::Start,
+                        bad_impl::TransitionState::Inc => abstract_model::TransitionState::Start,
+                        bad_impl::TransitionState::Done => abstract_model::TransitionState::Done,
+                    })
+                    .collect(),
+                counter: concrete.counter,
+            }
+        }
+    }
+
+    pub fn refinement_checker_serve(
+        num_threads: usize,
+    ) -> std::sync::Arc<
+        impl Checker<RefinementModel<bad_impl::Counter, abstract_model::Counter, Bad2AbstractMapper>>,
+    > {
+        let concrete = bad_impl::Counter {
+            threads: num_threads,
+        };
+        let abstractt = abstract_model::Counter {
+            threads: num_threads,
+        };
+        let mapper = Bad2AbstractMapper {
+            abstract_model: abstractt,
+        };
+        let refinement_model = RefinementModel::new(concrete, mapper);
+        let checker = refinement_model
+            .checker()
+            .threads(num_cpus::get())
+            .serve("127.0.0.1:3000");
+
+        checker
+    }
+}
+
+mod good_refine_abstract {
+    use stateright::{
+        refinement_mapping::{RefinementMapping, RefinementModel},
+        Checker, Model,
+    };
+
+    use crate::{abstract_model, good_impl};
+
+    #[derive(Debug, Hash, Clone, PartialEq)]
+    pub(crate) struct Good2AbstractMapper {
+        abstract_model: abstract_model::Counter,
+    }
+
+    // no auxiliary state is needed
+    // Mapping ==
+    //   INSTANCE abstract WITH
+    //     counter <- counter,
+    //     pc <- [t \in Threads |->
+    //       IF pc[t] = "inc" THEN "start"
+    //       ELSE pc[t]
+    //       ]
+    impl RefinementMapping<good_impl::Counter, abstract_model::Counter> for Good2AbstractMapper {
+        type AuxState = ();
+
+        fn abstract_model(&self) -> &abstract_model::Counter {
+            &self.abstract_model
+        }
+
+        fn init_aux_state(
+            &self,
+            _concrete: &<good_impl::Counter as stateright::Model>::State,
+        ) -> Self::AuxState {
+            ()
+        }
+
+        fn advance_aux_state(
+            &self,
+            _last_concrete: &<good_impl::Counter as stateright::Model>::State,
+            _last_aux: &Self::AuxState,
+            _action: &<good_impl::Counter as stateright::Model>::Action,
+            _next_concrete: &<good_impl::Counter as stateright::Model>::State,
+        ) -> Self::AuxState {
+            ()
+        }
+
+        fn map_state(
+            &self,
+            concrete: &<good_impl::Counter as stateright::Model>::State,
+            _aux: &Self::AuxState,
+        ) -> <abstract_model::Counter as stateright::Model>::State {
+            abstract_model::CounterState {
+                pc: concrete
+                    .pc
+                    .iter()
+                    .map(|s| match s {
+                        good_impl::TransitionState::Start => abstract_model::TransitionState::Start,
+                        good_impl::TransitionState::Inc => abstract_model::TransitionState::Start,
+                        good_impl::TransitionState::Done => abstract_model::TransitionState::Done,
+                    })
+                    .collect(),
+                counter: concrete.counter,
+            }
+        }
+    }
+
+    pub fn refinement_checker_serve(
+        num_threads: usize,
+    ) -> std::sync::Arc<
+        impl Checker<RefinementModel<good_impl::Counter, abstract_model::Counter, Good2AbstractMapper>>,
+    > {
+        let concrete = good_impl::Counter {
+            threads: num_threads,
+        };
+        let abstractt = abstract_model::Counter {
+            threads: num_threads,
+        };
+        let mapper = Good2AbstractMapper {
+            abstract_model: abstractt,
+        };
+        let refinement_model = RefinementModel::new(concrete, mapper);
+        let checker = refinement_model
+            .checker()
+            .threads(num_cpus::get())
+            .serve("127.0.0.1:3000");
+
+        checker
+    }
+}
+
+mod good_refine_bad {
+    use stateright::{
+        refinement_mapping::{RefinementMapping, RefinementModel},
+        Checker, Model,
+    };
+
+    use crate::{bad_impl, good_impl};
+
+    #[derive(Debug, Hash, Clone, PartialEq)]
+    pub(crate) struct Good2BadMapper {
+        abstract_model: bad_impl::Counter,
+    }
+
+    // no auxiliary state is needed
+    impl RefinementMapping<good_impl::Counter, bad_impl::Counter> for Good2BadMapper {
+        type AuxState = ();
+
+        fn abstract_model(&self) -> &bad_impl::Counter {
+            &self.abstract_model
+        }
+
+        fn init_aux_state(
+            &self,
+            _concrete: &<good_impl::Counter as stateright::Model>::State,
+        ) -> Self::AuxState {
+            ()
+        }
+
+        fn advance_aux_state(
+            &self,
+            _last_concrete: &<good_impl::Counter as stateright::Model>::State,
+            _last_aux: &Self::AuxState,
+            _action: &<good_impl::Counter as stateright::Model>::Action,
+            _next_concrete: &<good_impl::Counter as stateright::Model>::State,
+        ) -> Self::AuxState {
+            ()
+        }
+
+        fn map_state(
+            &self,
+            concrete: &<good_impl::Counter as stateright::Model>::State,
+            _aux: &Self::AuxState,
+        ) -> <bad_impl::Counter as stateright::Model>::State {
+            bad_impl::CounterState {
+                pc: concrete
+                    .pc
+                    .iter()
+                    .map(|s| match s {
+                        good_impl::TransitionState::Start => bad_impl::TransitionState::Start,
+                        good_impl::TransitionState::Inc => bad_impl::TransitionState::Inc,
+                        good_impl::TransitionState::Done => bad_impl::TransitionState::Done,
+                    })
+                    .collect(),
+                counter: concrete.counter,
+                tmp: concrete.tmp.clone(),
+            }
+        }
+    }
+
+    pub fn refinement_checker_serve(
+        num_threads: usize,
+    ) -> std::sync::Arc<
+        impl Checker<RefinementModel<good_impl::Counter, bad_impl::Counter, Good2BadMapper>>,
+    > {
+        let concrete = good_impl::Counter {
+            threads: num_threads,
+        };
+        let abstractt = bad_impl::Counter {
+            threads: num_threads,
+        };
+        let mapper = Good2BadMapper {
+            abstract_model: abstractt,
+        };
+        let refinement_model = RefinementModel::new(concrete, mapper);
+        let checker = refinement_model
+            .checker()
+            .threads(num_cpus::get())
+            .serve("127.0.0.1:3000");
+
+        checker
+    }
+}
+
+fn main() -> Result<(), pico_args::Error> {
+    env_logger::init_from_env(env_logger::Env::default().default_filter_or("info")); // `RUST_LOG=${LEVEL}` env variable to override
+
+    let mut args = pico_args::Arguments::from_env();
+    let num_threads = 2;
+    match args.subcommand()?.as_deref() {
+        Some("b2a") => {
+            println!(
+                "Checking refinement from bad implementation to abstract model. Serving on: http://127.0.0.1:3000"
+            );
+            try_bad_refine_abstract::refinement_checker_serve(num_threads);
+        }
+        Some("g2a") => {
+            println!(
+                "Checking refinement from good implementation to abstract model. Serving on: http://127.0.0.1:3000"
+            );
+            good_refine_abstract::refinement_checker_serve(num_threads);
+        }
+        Some("g2b") => {
+            println!(
+                "Checking refinement from good implementation to bad implementation. Serving on: http://127.0.0.1:3000"
+            );
+            good_refine_bad::refinement_checker_serve(num_threads);
+        }
+        _ => {
+            println!("Supported arguments:");
+            println!("  b2a");
+            println!("  g2a");
+            println!("  g2b");
+        }
+    }
+
+    Ok(())
+}

--- a/examples/multithreaded-counter.rs
+++ b/examples/multithreaded-counter.rs
@@ -149,24 +149,24 @@
 mod abstract_model {
     use stateright::Model;
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) enum CounterAction {
         Trans(usize), // Transfer the TransitionState of the thread with usize index.
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) enum TransitionState {
         Start,
         Done,
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) struct CounterState {
         pub pc: Vec<TransitionState>,
         pub counter: usize,
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) struct Counter {
         pub threads: usize,
     }
@@ -223,27 +223,27 @@ mod abstract_model {
 mod bad_impl {
     use stateright::Model;
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) enum CounterAction {
         GetCounter(usize), // get the global counter to update the thread's local counter
         IncCounter(usize), // update the global counter based on the thread's local counter
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) enum TransitionState {
         Start,
         Inc,
         Done,
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) struct CounterState {
         pub pc: Vec<TransitionState>,
         pub counter: usize,
         pub tmp: Vec<usize>, // local counter for each thread
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) struct Counter {
         pub threads: usize,
     }
@@ -306,20 +306,20 @@ mod good_impl {
 
     use stateright::Model;
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) enum CounterAction {
         LockAndGetCounter(usize),
         ReleaseAndIncCounter(usize),
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) enum TransitionState {
         Start,
         Inc,
         Done,
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) struct CounterState {
         pub pc: Vec<TransitionState>,
         pub counter: usize,
@@ -327,7 +327,7 @@ mod good_impl {
         pub lock: usize, // indicate which thread is holding the lock. if it's free, set the value to usize::MAX.
     }
 
-    #[derive(Debug, Clone, Hash, PartialEq)]
+    #[derive(Debug, Clone, Hash, PartialEq, Eq)]
     pub(crate) struct Counter {
         pub threads: usize,
     }
@@ -401,7 +401,7 @@ mod try_bad_refine_abstract {
 
     use crate::{abstract_model, bad_impl};
 
-    #[derive(Debug, Hash, Clone, PartialEq)]
+    #[derive(Debug, Hash, Clone, PartialEq, Eq)]
     pub(crate) struct Bad2AbstractMapper {
         abstract_model: abstract_model::Counter,
     }
@@ -416,6 +416,7 @@ mod try_bad_refine_abstract {
     //       ]
     impl RefinementMapping<bad_impl::Counter, abstract_model::Counter> for Bad2AbstractMapper {
         type AuxState = ();
+        type Observable = abstract_model::CounterState;
 
         fn abstract_model(&self) -> &abstract_model::Counter {
             &self.abstract_model
@@ -438,7 +439,7 @@ mod try_bad_refine_abstract {
             ()
         }
 
-        fn map_state(
+        fn refinement_map(
             &self,
             concrete: &<bad_impl::Counter as stateright::Model>::State,
             _aux: &Self::AuxState,
@@ -455,6 +456,13 @@ mod try_bad_refine_abstract {
                     .collect(),
                 counter: concrete.counter,
             }
+        }
+
+        fn observe(
+            &self,
+            a: &abstract_model::CounterState,
+        ) -> abstract_model::CounterState {
+            a.clone()
         }
     }
 
@@ -490,7 +498,7 @@ mod good_refine_abstract {
 
     use crate::{abstract_model, good_impl};
 
-    #[derive(Debug, Hash, Clone, PartialEq)]
+    #[derive(Debug, Hash, Clone, PartialEq, Eq)]
     pub(crate) struct Good2AbstractMapper {
         abstract_model: abstract_model::Counter,
     }
@@ -505,6 +513,7 @@ mod good_refine_abstract {
     //       ]
     impl RefinementMapping<good_impl::Counter, abstract_model::Counter> for Good2AbstractMapper {
         type AuxState = ();
+        type Observable = abstract_model::CounterState;
 
         fn abstract_model(&self) -> &abstract_model::Counter {
             &self.abstract_model
@@ -527,7 +536,7 @@ mod good_refine_abstract {
             ()
         }
 
-        fn map_state(
+        fn refinement_map(
             &self,
             concrete: &<good_impl::Counter as stateright::Model>::State,
             _aux: &Self::AuxState,
@@ -544,6 +553,13 @@ mod good_refine_abstract {
                     .collect(),
                 counter: concrete.counter,
             }
+        }
+
+        fn observe(
+            &self,
+            a: &abstract_model::CounterState,
+        ) -> abstract_model::CounterState {
+            a.clone()
         }
     }
 
@@ -579,7 +595,7 @@ mod good_refine_bad {
 
     use crate::{bad_impl, good_impl};
 
-    #[derive(Debug, Hash, Clone, PartialEq)]
+    #[derive(Debug, Hash, Clone, PartialEq, Eq)]
     pub(crate) struct Good2BadMapper {
         abstract_model: bad_impl::Counter,
     }
@@ -587,6 +603,7 @@ mod good_refine_bad {
     // no auxiliary state is needed
     impl RefinementMapping<good_impl::Counter, bad_impl::Counter> for Good2BadMapper {
         type AuxState = ();
+        type Observable = bad_impl::CounterState;
 
         fn abstract_model(&self) -> &bad_impl::Counter {
             &self.abstract_model
@@ -609,7 +626,7 @@ mod good_refine_bad {
             ()
         }
 
-        fn map_state(
+        fn refinement_map(
             &self,
             concrete: &<good_impl::Counter as stateright::Model>::State,
             _aux: &Self::AuxState,
@@ -627,6 +644,10 @@ mod good_refine_bad {
                 counter: concrete.counter,
                 tmp: concrete.tmp.clone(),
             }
+        }
+
+        fn observe(&self, a: &bad_impl::CounterState) -> bad_impl::CounterState {
+            a.clone()
         }
     }
 

--- a/examples/multithreaded-counter.rs
+++ b/examples/multithreaded-counter.rs
@@ -302,8 +302,6 @@ mod bad_impl {
 }
 
 mod good_impl {
-    use std::usize;
-
     use stateright::Model;
 
     #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -347,7 +345,7 @@ mod good_impl {
         }
 
         fn actions(&self, state: &Self::State, actions: &mut Vec<Self::Action>) {
-            (0..self.threads).into_iter().for_each(|idx| {
+            (0..self.threads).for_each(|idx| {
                 // if transition state is Start and lock is MAX, we can perform LockAndGetCounter action
                 if state.pc[idx] == TransitionState::Start && state.lock == usize::MAX {
                     actions.push(CounterAction::LockAndGetCounter(idx));
@@ -356,7 +354,6 @@ mod good_impl {
                 // if transition state is Inc and lock is me, we can perform ReleaseAndIncCounter action
                 if state.pc[idx] == TransitionState::Inc && state.lock == idx {
                     actions.push(CounterAction::ReleaseAndIncCounter(idx));
-                    return;
                 }
                 // otherwise, no action can be performed
             });
@@ -426,7 +423,6 @@ mod try_bad_refine_abstract {
             &self,
             _concrete: &<bad_impl::Counter as stateright::Model>::State,
         ) -> Self::AuxState {
-            ()
         }
 
         fn advance_aux_state(
@@ -436,7 +432,6 @@ mod try_bad_refine_abstract {
             _action: &<bad_impl::Counter as stateright::Model>::Action,
             _next_concrete: &<bad_impl::Counter as stateright::Model>::State,
         ) -> Self::AuxState {
-            ()
         }
 
         fn refinement_map(
@@ -458,10 +453,7 @@ mod try_bad_refine_abstract {
             }
         }
 
-        fn observe(
-            &self,
-            a: &abstract_model::CounterState,
-        ) -> abstract_model::CounterState {
+        fn observe(&self, a: &abstract_model::CounterState) -> abstract_model::CounterState {
             a.clone()
         }
     }
@@ -481,12 +473,11 @@ mod try_bad_refine_abstract {
             abstract_model: abstractt,
         };
         let refinement_model = RefinementModel::new(concrete, mapper);
-        let checker = refinement_model
+
+        refinement_model
             .checker()
             .threads(num_cpus::get())
-            .serve("127.0.0.1:3000");
-
-        checker
+            .serve("127.0.0.1:3000")
     }
 }
 
@@ -523,7 +514,6 @@ mod good_refine_abstract {
             &self,
             _concrete: &<good_impl::Counter as stateright::Model>::State,
         ) -> Self::AuxState {
-            ()
         }
 
         fn advance_aux_state(
@@ -533,7 +523,6 @@ mod good_refine_abstract {
             _action: &<good_impl::Counter as stateright::Model>::Action,
             _next_concrete: &<good_impl::Counter as stateright::Model>::State,
         ) -> Self::AuxState {
-            ()
         }
 
         fn refinement_map(
@@ -555,10 +544,7 @@ mod good_refine_abstract {
             }
         }
 
-        fn observe(
-            &self,
-            a: &abstract_model::CounterState,
-        ) -> abstract_model::CounterState {
+        fn observe(&self, a: &abstract_model::CounterState) -> abstract_model::CounterState {
             a.clone()
         }
     }
@@ -578,12 +564,11 @@ mod good_refine_abstract {
             abstract_model: abstractt,
         };
         let refinement_model = RefinementModel::new(concrete, mapper);
-        let checker = refinement_model
+
+        refinement_model
             .checker()
             .threads(num_cpus::get())
-            .serve("127.0.0.1:3000");
-
-        checker
+            .serve("127.0.0.1:3000")
     }
 }
 
@@ -613,7 +598,6 @@ mod good_refine_bad {
             &self,
             _concrete: &<good_impl::Counter as stateright::Model>::State,
         ) -> Self::AuxState {
-            ()
         }
 
         fn advance_aux_state(
@@ -623,7 +607,6 @@ mod good_refine_bad {
             _action: &<good_impl::Counter as stateright::Model>::Action,
             _next_concrete: &<good_impl::Counter as stateright::Model>::State,
         ) -> Self::AuxState {
-            ()
         }
 
         fn refinement_map(
@@ -666,12 +649,11 @@ mod good_refine_bad {
             abstract_model: abstractt,
         };
         let refinement_model = RefinementModel::new(concrete, mapper);
-        let checker = refinement_model
+
+        refinement_model
             .checker()
             .threads(num_cpus::get())
-            .serve("127.0.0.1:3000");
-
-        checker
+            .serve("127.0.0.1:3000")
     }
 }
 

--- a/examples/weak_counter.rs
+++ b/examples/weak_counter.rs
@@ -161,7 +161,7 @@ mod strict {
             &self.abstract_model
         }
 
-        fn init_aux_state(&self, _: &concrete_model::State) -> () {}
+        fn init_aux_state(&self, _: &concrete_model::State) {}
 
         fn advance_aux_state(
             &self,
@@ -169,14 +169,10 @@ mod strict {
             _: &(),
             _: &concrete_model::Action,
             _: &concrete_model::State,
-        ) -> () {
+        ) {
         }
 
-        fn refinement_map(
-            &self,
-            c: &concrete_model::State,
-            _: &(),
-        ) -> abstract_model::State {
+        fn refinement_map(&self, c: &concrete_model::State, _: &()) -> abstract_model::State {
             abstract_model::State {
                 pc: project_pc(&c.pc),
                 counter: c.counter,
@@ -192,9 +188,15 @@ mod strict {
     }
 
     pub fn run_check(num_threads: usize) {
-        let concrete = concrete_model::Counter { threads: num_threads };
-        let abstract_ = abstract_model::Counter { threads: num_threads };
-        let mapper = Mapper { abstract_model: abstract_ };
+        let concrete = concrete_model::Counter {
+            threads: num_threads,
+        };
+        let abstract_ = abstract_model::Counter {
+            threads: num_threads,
+        };
+        let mapper = Mapper {
+            abstract_model: abstract_,
+        };
         let model = RefinementModel::new(concrete, mapper);
         let checker = model.checker().threads(num_cpus::get()).spawn_bfs().join();
         match checker.discovery("check_simulation") {
@@ -209,11 +211,20 @@ mod strict {
     }
 
     pub fn run_serve(num_threads: usize) {
-        let concrete = concrete_model::Counter { threads: num_threads };
-        let abstract_ = abstract_model::Counter { threads: num_threads };
-        let mapper = Mapper { abstract_model: abstract_ };
+        let concrete = concrete_model::Counter {
+            threads: num_threads,
+        };
+        let abstract_ = abstract_model::Counter {
+            threads: num_threads,
+        };
+        let mapper = Mapper {
+            abstract_model: abstract_,
+        };
         let model = RefinementModel::new(concrete, mapper);
-        model.checker().threads(num_cpus::get()).serve("127.0.0.1:3000");
+        model
+            .checker()
+            .threads(num_cpus::get())
+            .serve("127.0.0.1:3000");
     }
 }
 
@@ -244,7 +255,7 @@ mod weak {
             &self.abstract_model
         }
 
-        fn init_aux_state(&self, _: &concrete_model::State) -> () {}
+        fn init_aux_state(&self, _: &concrete_model::State) {}
 
         fn advance_aux_state(
             &self,
@@ -252,14 +263,10 @@ mod weak {
             _: &(),
             _: &concrete_model::Action,
             _: &concrete_model::State,
-        ) -> () {
+        ) {
         }
 
-        fn refinement_map(
-            &self,
-            c: &concrete_model::State,
-            _: &(),
-        ) -> abstract_model::State {
+        fn refinement_map(&self, c: &concrete_model::State, _: &()) -> abstract_model::State {
             abstract_model::State {
                 pc: project_pc(&c.pc),
                 counter: c.counter,
@@ -276,28 +283,41 @@ mod weak {
     }
 
     pub fn run_check(num_threads: usize) {
-        let concrete = concrete_model::Counter { threads: num_threads };
-        let abstract_ = abstract_model::Counter { threads: num_threads };
-        let mapper = Mapper { abstract_model: abstract_ };
+        let concrete = concrete_model::Counter {
+            threads: num_threads,
+        };
+        let abstract_ = abstract_model::Counter {
+            threads: num_threads,
+        };
+        let mapper = Mapper {
+            abstract_model: abstract_,
+        };
         let model = RefinementModel::new(concrete, mapper);
         let checker = model.checker().threads(num_cpus::get()).spawn_bfs().join();
         match checker.discovery("check_simulation") {
             Some(_) => println!(
                 "  Refinement FAILED — unexpected, `last_actor` should be hidden by Observable."
             ),
-            None => println!(
-                "  Refinement passed (expected for weak Observable)."
-            ),
+            None => println!("  Refinement passed (expected for weak Observable)."),
         }
         println!("  State count: {}", checker.state_count());
     }
 
     pub fn run_serve(num_threads: usize) {
-        let concrete = concrete_model::Counter { threads: num_threads };
-        let abstract_ = abstract_model::Counter { threads: num_threads };
-        let mapper = Mapper { abstract_model: abstract_ };
+        let concrete = concrete_model::Counter {
+            threads: num_threads,
+        };
+        let abstract_ = abstract_model::Counter {
+            threads: num_threads,
+        };
+        let mapper = Mapper {
+            abstract_model: abstract_,
+        };
         let model = RefinementModel::new(concrete, mapper);
-        model.checker().threads(num_cpus::get()).serve("127.0.0.1:3000");
+        model
+            .checker()
+            .threads(num_cpus::get())
+            .serve("127.0.0.1:3000");
     }
 }
 
@@ -316,20 +336,18 @@ fn main() -> Result<(), pico_args::Error> {
             weak::run_check(num_threads);
         }
         Some("strict-serve") => {
-            println!(
-                "Strict Observable — serving counterexample SVG at http://127.0.0.1:3000"
-            );
+            println!("Strict Observable — serving counterexample SVG at http://127.0.0.1:3000");
             strict::run_serve(num_threads);
         }
         Some("weak-serve") => {
-            println!(
-                "Weak Observable — serving at http://127.0.0.1:3000"
-            );
+            println!("Weak Observable — serving at http://127.0.0.1:3000");
             weak::run_serve(num_threads);
         }
         _ => {
             println!("USAGE:");
-            println!("  ./weak_counter strict          # check strict Observable (expected to fail)");
+            println!(
+                "  ./weak_counter strict          # check strict Observable (expected to fail)"
+            );
             println!("  ./weak_counter weak            # check weak Observable (expected to pass)");
             println!("  ./weak_counter strict-serve    # serve counterexample SVG on port 3000");
             println!("  ./weak_counter weak-serve      # serve SVG on port 3000");

--- a/examples/weak_counter.rs
+++ b/examples/weak_counter.rs
@@ -1,0 +1,340 @@
+//! Demonstrates **weak simulation** in the refinement mapping framework.
+//!
+//! The abstract spec carries an internal `last_actor` field — bookkeeping
+//! that records which thread took the most recent transition. The concrete
+//! model has no access to that information (it's a simpler two-thread
+//! counter), so any refinement mapping has to make something up for
+//! `last_actor`.
+//!
+//! - Under **strict** `Observable` (the entire abstract state is
+//!   observable), the refinement check fails: the mapping sets
+//!   `last_actor = None` always, but the abstract's transitions
+//!   produce `Some(thread)`. The mismatch is visible, so the check
+//!   rejects the mapping.
+//!
+//! - Under **weak** `Observable` (project away `last_actor`), the same
+//!   mapping succeeds. The bookkeeping is hidden from the contract, so
+//!   the concrete only has to simulate the `(pc, counter)` pair — which
+//!   it does faithfully.
+//!
+//! This is the canonical pattern for weak simulation: keep internal
+//! ghost/bookkeeping fields in the abstract spec (for clarity or for
+//! stating invariants), but restrict the refinement obligation to the
+//! fields that are part of the observable contract.
+
+mod abstract_model {
+    use stateright::Model;
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    pub enum ThreadState {
+        Start,
+        Done,
+    }
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    pub struct Action(pub usize);
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    pub struct State {
+        pub pc: Vec<ThreadState>,
+        pub counter: u32,
+        /// Internal bookkeeping — tracks which thread took the last
+        /// transition. Part of the abstract spec but NOT part of the
+        /// observable contract under weak simulation.
+        pub last_actor: Option<usize>,
+    }
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    pub struct Counter {
+        pub threads: usize,
+    }
+
+    impl Model for Counter {
+        type State = State;
+        type Action = Action;
+
+        fn init_states(&self) -> Vec<Self::State> {
+            vec![State {
+                pc: vec![ThreadState::Start; self.threads],
+                counter: 0,
+                last_actor: None,
+            }]
+        }
+
+        fn actions(&self, state: &Self::State, actions: &mut Vec<Self::Action>) {
+            for (idx, ts) in state.pc.iter().enumerate() {
+                if *ts == ThreadState::Start {
+                    actions.push(Action(idx));
+                }
+            }
+        }
+
+        fn next_state(&self, last: &Self::State, action: Self::Action) -> Option<Self::State> {
+            let Action(idx) = action;
+            let mut next = last.clone();
+            next.pc[idx] = ThreadState::Done;
+            next.counter += 1;
+            next.last_actor = Some(idx);
+            Some(next)
+        }
+    }
+}
+
+mod concrete_model {
+    use stateright::Model;
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    pub enum ThreadState {
+        Start,
+        Done,
+    }
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    pub struct Action(pub usize);
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    pub struct State {
+        pub pc: Vec<ThreadState>,
+        pub counter: u32,
+    }
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    pub struct Counter {
+        pub threads: usize,
+    }
+
+    impl Model for Counter {
+        type State = State;
+        type Action = Action;
+
+        fn init_states(&self) -> Vec<Self::State> {
+            vec![State {
+                pc: vec![ThreadState::Start; self.threads],
+                counter: 0,
+            }]
+        }
+
+        fn actions(&self, state: &Self::State, actions: &mut Vec<Self::Action>) {
+            for (idx, ts) in state.pc.iter().enumerate() {
+                if *ts == ThreadState::Start {
+                    actions.push(Action(idx));
+                }
+            }
+        }
+
+        fn next_state(&self, last: &Self::State, action: Self::Action) -> Option<Self::State> {
+            let Action(idx) = action;
+            let mut next = last.clone();
+            next.pc[idx] = ThreadState::Done;
+            next.counter += 1;
+            Some(next)
+        }
+    }
+}
+
+fn project_pc(c: &[concrete_model::ThreadState]) -> Vec<abstract_model::ThreadState> {
+    c.iter()
+        .map(|s| match s {
+            concrete_model::ThreadState::Start => abstract_model::ThreadState::Start,
+            concrete_model::ThreadState::Done => abstract_model::ThreadState::Done,
+        })
+        .collect()
+}
+
+/// Refinement mapping under **strict** Observable. Refinement should FAIL.
+mod strict {
+    use super::*;
+    use stateright::refinement_mapping::{RefinementMapping, RefinementModel};
+    use stateright::{Checker, Model};
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    pub struct Mapper {
+        pub abstract_model: abstract_model::Counter,
+    }
+
+    impl RefinementMapping<concrete_model::Counter, abstract_model::Counter> for Mapper {
+        type AuxState = ();
+        /// Strict Observable = full abstract state, including `last_actor`.
+        type Observable = abstract_model::State;
+
+        fn abstract_model(&self) -> &abstract_model::Counter {
+            &self.abstract_model
+        }
+
+        fn init_aux_state(&self, _: &concrete_model::State) -> () {}
+
+        fn advance_aux_state(
+            &self,
+            _: &concrete_model::State,
+            _: &(),
+            _: &concrete_model::Action,
+            _: &concrete_model::State,
+        ) -> () {
+        }
+
+        fn refinement_map(
+            &self,
+            c: &concrete_model::State,
+            _: &(),
+        ) -> abstract_model::State {
+            abstract_model::State {
+                pc: project_pc(&c.pc),
+                counter: c.counter,
+                // The concrete has no idea which thread last acted, so the
+                // mapping cannot produce the "right" value here.
+                last_actor: None,
+            }
+        }
+
+        fn observe(&self, a: &abstract_model::State) -> abstract_model::State {
+            a.clone()
+        }
+    }
+
+    pub fn run_check(num_threads: usize) {
+        let concrete = concrete_model::Counter { threads: num_threads };
+        let abstract_ = abstract_model::Counter { threads: num_threads };
+        let mapper = Mapper { abstract_model: abstract_ };
+        let model = RefinementModel::new(concrete, mapper);
+        let checker = model.checker().threads(num_cpus::get()).spawn_bfs().join();
+        match checker.discovery("check_simulation") {
+            Some(_) => println!(
+                "  Refinement FAILED — counterexample found (expected for strict Observable)."
+            ),
+            None => println!(
+                "  Refinement passed — unexpected for strict Observable with garbage `last_actor`."
+            ),
+        }
+        println!("  State count: {}", checker.state_count());
+    }
+
+    pub fn run_serve(num_threads: usize) {
+        let concrete = concrete_model::Counter { threads: num_threads };
+        let abstract_ = abstract_model::Counter { threads: num_threads };
+        let mapper = Mapper { abstract_model: abstract_ };
+        let model = RefinementModel::new(concrete, mapper);
+        model.checker().threads(num_cpus::get()).serve("127.0.0.1:3000");
+    }
+}
+
+/// Refinement mapping under **weak** Observable. Refinement should PASS.
+mod weak {
+    use super::*;
+    use stateright::refinement_mapping::{RefinementMapping, RefinementModel};
+    use stateright::{Checker, Model};
+
+    /// Observable projection: everything in the abstract state EXCEPT
+    /// `last_actor`. This is the contract the refinement preserves.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct Obs {
+        pub pc: Vec<abstract_model::ThreadState>,
+        pub counter: u32,
+    }
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    pub struct Mapper {
+        pub abstract_model: abstract_model::Counter,
+    }
+
+    impl RefinementMapping<concrete_model::Counter, abstract_model::Counter> for Mapper {
+        type AuxState = ();
+        type Observable = Obs;
+
+        fn abstract_model(&self) -> &abstract_model::Counter {
+            &self.abstract_model
+        }
+
+        fn init_aux_state(&self, _: &concrete_model::State) -> () {}
+
+        fn advance_aux_state(
+            &self,
+            _: &concrete_model::State,
+            _: &(),
+            _: &concrete_model::Action,
+            _: &concrete_model::State,
+        ) -> () {
+        }
+
+        fn refinement_map(
+            &self,
+            c: &concrete_model::State,
+            _: &(),
+        ) -> abstract_model::State {
+            abstract_model::State {
+                pc: project_pc(&c.pc),
+                counter: c.counter,
+                last_actor: None,
+            }
+        }
+
+        fn observe(&self, a: &abstract_model::State) -> Obs {
+            Obs {
+                pc: a.pc.clone(),
+                counter: a.counter,
+            }
+        }
+    }
+
+    pub fn run_check(num_threads: usize) {
+        let concrete = concrete_model::Counter { threads: num_threads };
+        let abstract_ = abstract_model::Counter { threads: num_threads };
+        let mapper = Mapper { abstract_model: abstract_ };
+        let model = RefinementModel::new(concrete, mapper);
+        let checker = model.checker().threads(num_cpus::get()).spawn_bfs().join();
+        match checker.discovery("check_simulation") {
+            Some(_) => println!(
+                "  Refinement FAILED — unexpected, `last_actor` should be hidden by Observable."
+            ),
+            None => println!(
+                "  Refinement passed (expected for weak Observable)."
+            ),
+        }
+        println!("  State count: {}", checker.state_count());
+    }
+
+    pub fn run_serve(num_threads: usize) {
+        let concrete = concrete_model::Counter { threads: num_threads };
+        let abstract_ = abstract_model::Counter { threads: num_threads };
+        let mapper = Mapper { abstract_model: abstract_ };
+        let model = RefinementModel::new(concrete, mapper);
+        model.checker().threads(num_cpus::get()).serve("127.0.0.1:3000");
+    }
+}
+
+fn main() -> Result<(), pico_args::Error> {
+    env_logger::init_from_env(env_logger::Env::default().default_filter_or("info"));
+
+    let mut args = pico_args::Arguments::from_env();
+    let num_threads = 2;
+    match args.subcommand()?.as_deref() {
+        Some("strict") => {
+            println!("Strict Observable — refinement SHOULD fail:");
+            strict::run_check(num_threads);
+        }
+        Some("weak") => {
+            println!("Weak Observable — refinement SHOULD pass:");
+            weak::run_check(num_threads);
+        }
+        Some("strict-serve") => {
+            println!(
+                "Strict Observable — serving counterexample SVG at http://127.0.0.1:3000"
+            );
+            strict::run_serve(num_threads);
+        }
+        Some("weak-serve") => {
+            println!(
+                "Weak Observable — serving at http://127.0.0.1:3000"
+            );
+            weak::run_serve(num_threads);
+        }
+        _ => {
+            println!("USAGE:");
+            println!("  ./weak_counter strict          # check strict Observable (expected to fail)");
+            println!("  ./weak_counter weak            # check weak Observable (expected to pass)");
+            println!("  ./weak_counter strict-serve    # serve counterexample SVG on port 3000");
+            println!("  ./weak_counter weak-serve      # serve SVG on port 3000");
+        }
+    }
+
+    Ok(())
+}

--- a/src/actor/network.rs
+++ b/src/actor/network.rs
@@ -166,7 +166,7 @@ where
     }
 
     /// Returns an iterator over all envelopes in the network.
-    pub fn iter_all(&self) -> NetworkIter<Msg> {
+    pub fn iter_all(&self) -> NetworkIter<'_, Msg> {
         match self {
             Network::UnorderedDuplicating(set, _) => NetworkIter::UnorderedDuplicating(set.iter()),
             Network::UnorderedNonDuplicating(multiset) => {
@@ -177,7 +177,7 @@ where
     }
 
     /// Returns an iterator over all distinct deliverable envelopes in the network.
-    pub fn iter_deliverable(&self) -> NetworkDeliverableIter<Msg> {
+    pub fn iter_deliverable(&self) -> NetworkDeliverableIter<'_, Msg> {
         match self {
             Network::UnorderedDuplicating(set, _) => {
                 NetworkDeliverableIter::UnorderedDuplicating(set.iter())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,6 +146,7 @@ mod test_util;
 pub mod actor;
 pub use checker::*;
 pub use has_discoveries::HasDiscoveries;
+pub mod refinement_mapping;
 pub mod semantics;
 pub mod util;
 

--- a/src/refinement_mapping.rs
+++ b/src/refinement_mapping.rs
@@ -141,7 +141,7 @@ where
     A: Model,
     A::State: Clone + PartialEq + Debug + Hash,
     Map: RefinementMapping<C, A>,
-    Map::AuxState: Clone,
+    Map::AuxState: Clone + Hash + Debug,
 {
     type State = RefinementModelState<C, A, Map>;
 
@@ -220,61 +220,89 @@ where
         };
 
         let mut abstract_slots = HashMap::new();
-        let mut abstract_nodes = Vec::new();
-        let mut abstract_path_slots = Vec::new();
-        let mut concrete_nodes = Vec::new();
-        let mut mapping_slots = Vec::new();
+        let mut concrete_slots = HashMap::new();
 
-        for (step_idx, (state, _action)) in steps.iter().enumerate() {
-            // Concrete node
+        let mut abstract_nodes = Vec::new();
+        let mut concrete_nodes = Vec::new();
+        let mut middle_nodes = Vec::new();
+
+        let mut abstract_path_slots = Vec::new();
+        let mut concrete_path_slots = Vec::new();
+
+        for (step_idx, (state, _)) in steps.iter().enumerate() {
+            // Concrete (deduped)
             let concrete_fp = fingerprint(&state.concrete_state).get();
-            concrete_nodes.push(NodeMeta {
-                label: format!("C{step_idx}"),
+            let concrete_slot = *concrete_slots.entry(concrete_fp).or_insert_with(|| {
+                let slot = concrete_nodes.len();
+                concrete_nodes.push(NodeMeta {
+                    label: format!("C{slot}"),
+                    title: build_title(
+                        "Concrete",
+                        slot,
+                        concrete_fp,
+                        format!("{:#?}", state.concrete_state),
+                    ),
+                });
+                slot
+            });
+            concrete_path_slots.push(concrete_slot);
+
+            // Concrete + Aux (per step)
+            let combo_fp =
+                fingerprint(&(state.concrete_state.clone(), state.aux_state.clone())).get();
+            middle_nodes.push(NodeMeta {
+                label: format!("CA{step_idx}"),
                 title: build_title(
-                    "Concrete",
+                    "Concrete+Aux",
                     step_idx,
-                    concrete_fp,
-                    format!("{:#?}", state.concrete_state),
+                    combo_fp,
+                    format!(
+                        "Concrete: {:#?}\nAux: {:#?}",
+                        state.concrete_state, state.aux_state
+                    ),
                 ),
             });
 
-            // Abstract node (deduped via fingerprint)
+            // Abstract (deduped)
             let abstract_fp = fingerprint(&state.mapped_abstract_state).get();
-            let slot = *abstract_slots.entry(abstract_fp).or_insert_with(|| {
-                let slot_idx = abstract_nodes.len();
+            let abstract_slot = *abstract_slots.entry(abstract_fp).or_insert_with(|| {
+                let slot = abstract_nodes.len();
                 abstract_nodes.push(NodeMeta {
-                    label: format!("A{slot_idx}"),
+                    label: format!("A{slot}"),
                     title: build_title(
                         "Abstract",
-                        slot_idx,
+                        slot,
                         abstract_fp,
                         format!("{:#?}", state.mapped_abstract_state),
                     ),
                 });
-                slot_idx
+                slot
             });
-            abstract_path_slots.push(slot);
-            mapping_slots.push(slot);
+            abstract_path_slots.push(abstract_slot);
         }
 
         let last_state = &steps.last().unwrap().0;
         let last_is_valid = Self::check_simulation(self, last_state);
 
         let horizontal_gap = 150usize;
-        let vertical_gap = 160usize;
+        let vertical_gap = 120usize;
         let left_padding = 140usize;
         let right_padding = 120usize;
         let top_padding = 80usize;
         let radius = 22usize;
 
         let span = std::cmp::max(
-            abstract_nodes.len().saturating_sub(1),
-            concrete_nodes.len().saturating_sub(1),
+            std::cmp::max(
+                abstract_nodes.len().saturating_sub(1),
+                concrete_nodes.len().saturating_sub(1),
+            ),
+            middle_nodes.len().saturating_sub(1),
         );
         let width = left_padding + right_padding + horizontal_gap.saturating_mul(span);
-        let height = top_padding * 2 + vertical_gap;
+        let height = top_padding * 3 + vertical_gap * 2;
         let abstract_y = top_padding;
-        let concrete_y = top_padding + vertical_gap;
+        let middle_y = abstract_y + vertical_gap;
+        let concrete_y = middle_y + vertical_gap;
 
         let mut svg = String::new();
         let _ = write!(
@@ -292,29 +320,37 @@ where
       );
         let _ = write!(
             &mut svg,
-            "<text class='svg-ref-label' x='20' y='{abstract_y}'>Abstract Model</text>\
-           <text class='svg-ref-label' x='20' y='{concrete_y}'>Concrete Model</text>"
+            "<text class='svg-ref-label' x='20' y='{abstract_y}'>Abstract</text>\
+           <text class='svg-ref-label' x='12' y='{middle_y}'>Concrete+Aux</text>\
+           <text class='svg-ref-label' x='20' y='{concrete_y}'>Concrete</text>"
         );
 
-        // Concrete transitions
-        for window in (0..concrete_nodes.len()).collect::<Vec<_>>().windows(2) {
-            if let [left, right] = window {
-                let _ = write!(
-                    &mut svg,
-                    "<line x1='{x1}' y1='{concrete_y}' x2='{x2}' y2='{concrete_y}' \
-                     class='svg-ref-edge' marker-end='url(#refinement-arrow)'/>",
-                    x1 = left_padding + left * horizontal_gap,
-                    x2 = left_padding + right * horizontal_gap,
-                );
-            }
+        // Concrete transitions (deduped path)
+        for i in 1..concrete_path_slots.len() {
+            let x1 = left_padding + concrete_path_slots[i - 1] * horizontal_gap;
+            let x2 = left_padding + concrete_path_slots[i] * horizontal_gap;
+            let _ = write!(
+                &mut svg,
+                "<line x1='{x1}' y1='{concrete_y}' x2='{x2}' y2='{concrete_y}' \
+                 class='svg-ref-edge' marker-end='url(#refinement-arrow)'/>",
+            );
         }
 
-        // Abstract transitions (mark final edge dashed if last state invalid)
+        // Middle transitions (per step)
+        for step_idx in 1..middle_nodes.len() {
+            let x1 = left_padding + (step_idx - 1) * horizontal_gap;
+            let x2 = left_padding + step_idx * horizontal_gap;
+            let _ = write!(
+                &mut svg,
+                "<line x1='{x1}' y1='{middle_y}' x2='{x2}' y2='{middle_y}' \
+                 class='svg-ref-edge' marker-end='url(#refinement-arrow)'/>",
+            );
+        }
+
+        // Abstract transitions (deduped path, last edge dashed if invalid)
         for i in 1..abstract_path_slots.len() {
-            let start_slot = abstract_path_slots[i - 1];
-            let end_slot = abstract_path_slots[i];
-            let x1 = left_padding + start_slot * horizontal_gap;
-            let x2 = left_padding + end_slot * horizontal_gap;
+            let x1 = left_padding + abstract_path_slots[i - 1] * horizontal_gap;
+            let x2 = left_padding + abstract_path_slots[i] * horizontal_gap;
             let mut class = "svg-ref-edge";
             let mut cross = None;
             if i == abstract_path_slots.len() - 1 && !last_is_valid {
@@ -342,16 +378,30 @@ where
             }
         }
 
-        // Mapping lines
-        for (step_idx, slot_idx) in mapping_slots.iter().enumerate() {
+        // Concrete -> middle mappings (per step)
+        for (step_idx, &slot_idx) in concrete_path_slots.iter().enumerate() {
+            let concrete_x = left_padding + slot_idx * horizontal_gap;
+            let middle_x = left_padding + step_idx * horizontal_gap;
             let _ = write!(
-                &mut svg,
-                "<line x1='{cx}' y1='{y1}' x2='{ax}' y2='{y2}' class='svg-ref-mapping-line'/>",
-                cx = left_padding + step_idx * horizontal_gap,
-                y1 = concrete_y - radius,
-                ax = left_padding + slot_idx * horizontal_gap,
-                y2 = abstract_y + radius,
-            );
+              &mut svg,
+              "<line x1='{concrete_x}' y1='{concrete_y_minus}' x2='{middle_x}' y2='{middle_y_plus}' \
+                 class='svg-ref-mapping-line'/>",
+              concrete_y_minus = concrete_y - radius,
+              middle_y_plus = middle_y + radius,
+          );
+        }
+
+        // Middle -> abstract mappings (per step)
+        for (step_idx, &slot_idx) in abstract_path_slots.iter().enumerate() {
+            let middle_x = left_padding + step_idx * horizontal_gap;
+            let abstract_x = left_padding + slot_idx * horizontal_gap;
+            let _ = write!(
+              &mut svg,
+              "<line x1='{middle_x}' y1='{middle_y_minus}' x2='{abstract_x}' y2='{abstract_y_plus}' \
+                 class='svg-ref-mapping-line'/>",
+              middle_y_minus = middle_y - radius,
+              abstract_y_plus = abstract_y + radius,
+          );
         }
 
         // Abstract nodes
@@ -370,9 +420,25 @@ where
             );
         }
 
-        // Concrete nodes
-        for (step_idx, node) in concrete_nodes.iter().enumerate() {
+        // Middle nodes
+        for (step_idx, node) in middle_nodes.iter().enumerate() {
             let x = left_padding + step_idx * horizontal_gap;
+            let _ = write!(
+                &mut svg,
+                "<g class='svg-ref-node'>\
+                 <circle class='svg-ref-state-circle' cx='{x}' cy='{middle_y}' r='{radius}'>\
+                   <title>{title}</title>\
+                 </circle>\
+                 <text class='svg-ref-state-text' x='{x}' y='{middle_y}'>{label}</text>\
+               </g>",
+                title = Self::escape_html(&node.title),
+                label = Self::escape_html(&node.label),
+            );
+        }
+
+        // Concrete nodes
+        for (slot_idx, node) in concrete_nodes.iter().enumerate() {
+            let x = left_padding + slot_idx * horizontal_gap;
             let _ = write!(
                 &mut svg,
                 "<g class='svg-ref-node'>\

--- a/src/refinement_mapping.rs
+++ b/src/refinement_mapping.rs
@@ -1,5 +1,6 @@
 use crate::{fingerprint, Model, Property};
 use std::{
+    collections::HashMap,
     fmt::{Debug, Write},
     hash::Hash,
     marker::PhantomData,
@@ -205,26 +206,16 @@ where
             return None;
         }
 
-        struct Node {
-            x: usize,
-            y: usize,
+        #[derive(Clone)]
+        struct NodeMeta {
             label: String,
             title: String,
         }
 
-        let node_count = steps.len();
-        let horizontal_gap = 150usize;
-        let vertical_gap = 160usize;
-        let left_padding = 140usize;
-        let right_padding = 120usize;
-        let top_padding = 80usize;
-        let radius = 22usize;
-        let width = left_padding
-            + right_padding
-            + horizontal_gap.saturating_mul(node_count.saturating_sub(1));
-        let height = top_padding * 2 + vertical_gap;
-        let abstract_y = top_padding;
-        let concrete_y = top_padding + vertical_gap;
+        let mut abstract_slots: HashMap<u64, usize> = HashMap::new();
+        let mut abstract_nodes = Vec::new();
+        let mut concrete_nodes = Vec::new();
+        let mut mapping_slots = Vec::new();
 
         let build_title = |kind: &str, idx: usize, fp: u64, value: String| -> String {
             format!(
@@ -233,35 +224,52 @@ where
             )
         };
 
-        let mut abstract_nodes = Vec::with_capacity(node_count);
-        let mut concrete_nodes = Vec::with_capacity(node_count);
-        for (idx, (state, _)) in steps.iter().enumerate() {
-            let x = left_padding + idx * horizontal_gap;
-            let abstract_fp = fingerprint(&state.mapped_abstract_state).get();
+        for (step_idx, (state, _)) in steps.iter().enumerate() {
+            // Concrete node metadata always uses the step index.
             let concrete_fp = fingerprint(&state.concrete_state).get();
-            abstract_nodes.push(Node {
-                x,
-                y: abstract_y,
-                label: format!("A{idx}"),
-                title: build_title(
-                    "Abstract",
-                    idx,
-                    abstract_fp,
-                    format!("{:#?}", state.mapped_abstract_state),
-                ),
-            });
-            concrete_nodes.push(Node {
-                x,
-                y: concrete_y,
-                label: format!("C{idx}"),
+            concrete_nodes.push(NodeMeta {
+                label: format!("C{step_idx}"),
                 title: build_title(
                     "Concrete",
-                    idx,
+                    step_idx,
                     concrete_fp,
                     format!("{:#?}", state.concrete_state),
                 ),
             });
+
+            // Abstract nodes dedupe via fingerprint/slot.
+            let abstract_fp = fingerprint(&state.mapped_abstract_state).get();
+            let slot = *abstract_slots.entry(abstract_fp).or_insert_with(|| {
+                let slot_idx = abstract_nodes.len();
+                abstract_nodes.push(NodeMeta {
+                    label: format!("A{slot_idx}"),
+                    title: build_title(
+                        "Abstract",
+                        slot_idx,
+                        abstract_fp,
+                        format!("{:#?}", state.mapped_abstract_state),
+                    ),
+                });
+                slot_idx
+            });
+            mapping_slots.push(slot);
         }
+
+        let horizontal_gap = 150usize;
+        let vertical_gap = 160usize;
+        let left_padding = 140usize;
+        let right_padding = 120usize;
+        let top_padding = 80usize;
+        let radius = 22usize;
+
+        let span = std::cmp::max(
+            abstract_nodes.len().saturating_sub(1),
+            concrete_nodes.len().saturating_sub(1),
+        );
+        let width = left_padding + right_padding + horizontal_gap.saturating_mul(span);
+        let height = top_padding * 2 + vertical_gap;
+        let abstract_y = top_padding;
+        let concrete_y = top_padding + vertical_gap;
 
         let mut svg = String::new();
         let _ = write!(
@@ -279,47 +287,75 @@ where
       );
         let _ = write!(
             &mut svg,
-            "<text class='svg-ref-label' x='20' y='{abstract_y}'>Abstract</text>\
-           <text class='svg-ref-label' x='20' y='{concrete_y}'>Concrete+Aux</text>"
+            "<text class='svg-ref-label' x='20' y='{abstract_y}'>Abstract Model</text>\
+           <text class='svg-ref-label' x='20' y='{concrete_y}'>Concrete Model</text>"
         );
 
-        for nodes in [&abstract_nodes, &concrete_nodes] {
-            for window in nodes.windows(2) {
-                if let [left, right] = window {
-                    let _ = write!(
-                      &mut svg,
-                      "<line x1='{x1}' y1='{y1}' x2='{x2}' y2='{y2}' class='svg-ref-edge' marker-end='url(#refinement-arrow)'/>",
-                      x1 = left.x,
-                      y1 = left.y,
-                      x2 = right.x,
-                      y2 = right.y
-                  );
-                }
+        // Concrete transition edges (solid, sequential).
+        for window in (0..concrete_nodes.len()).collect::<Vec<_>>().windows(2) {
+            if let [left, right] = window {
+                let _ = write!(
+                  &mut svg,
+                  "<line x1='{x1}' y1='{con_y}' x2='{x2}' y2='{con_y}' class='svg-ref-edge' marker-end='url(#refinement-arrow)'/>",
+                  x1 = left_padding + left * horizontal_gap,
+                  x2 = left_padding + right * horizontal_gap,
+                  con_y = concrete_y,
+              );
             }
         }
 
-        for (abstract_node, concrete_node) in abstract_nodes.iter().zip(concrete_nodes.iter()) {
+        // Abstract transition edges (solid between slot ordering).
+        for window in (0..abstract_nodes.len()).collect::<Vec<_>>().windows(2) {
+            if let [left, right] = window {
+                let _ = write!(
+                  &mut svg,
+                  "<line x1='{x1}' y1='{abs_y}' x2='{x2}' y2='{abs_y}' class='svg-ref-edge' marker-end='url(#refinement-arrow)'/>",
+                  x1 = left_padding + left * horizontal_gap,
+                  x2 = left_padding + right * horizontal_gap,
+                  abs_y = abstract_y,
+              );
+            }
+        }
+
+        // Mapping lines from each concrete state to its abstract slot.
+        for (step_idx, slot_idx) in mapping_slots.into_iter().enumerate() {
             let _ = write!(
                 &mut svg,
-                "<line x1='{x}' y1='{y1}' x2='{x}' y2='{y2}' class='svg-ref-mapping-line'/>",
-                x = abstract_node.x,
-                y1 = abstract_node.y + radius,
-                y2 = concrete_node.y - radius
+                "<line x1='{x1}' y1='{y1}' x2='{x2}' y2='{y2}' class='svg-ref-mapping-line'/>",
+                x1 = left_padding + step_idx * horizontal_gap,
+                y1 = concrete_y - radius,
+                x2 = left_padding + slot_idx * horizontal_gap,
+                y2 = abstract_y + radius,
             );
         }
 
-        for node in abstract_nodes.iter().chain(concrete_nodes.iter()) {
+        // Emit abstract circles.
+        for (slot_idx, node) in abstract_nodes.iter().enumerate() {
+            let x = left_padding + slot_idx * horizontal_gap;
             let _ = write!(
                 &mut svg,
                 "<g class='svg-ref-node'>\
-                 <circle class='svg-ref-state-circle' cx='{x}' cy='{y}' r='{radius}'>\
+                 <circle class='svg-ref-state-circle' cx='{x}' cy='{abstract_y}' r='{radius}'>\
                    <title>{title}</title>\
                  </circle>\
-                 <text class='svg-ref-state-text' x='{x}' y='{y}'>{label}</text>\
+                 <text class='svg-ref-state-text' x='{x}' y='{abstract_y}'>{label}</text>\
                </g>",
-                x = node.x,
-                y = node.y,
-                radius = radius,
+                title = Self::escape_html(&node.title),
+                label = Self::escape_html(&node.label),
+            );
+        }
+
+        // Emit concrete circles.
+        for (step_idx, node) in concrete_nodes.iter().enumerate() {
+            let x = left_padding + step_idx * horizontal_gap;
+            let _ = write!(
+                &mut svg,
+                "<g class='svg-ref-node'>\
+                 <circle class='svg-ref-state-circle' cx='{x}' cy='{concrete_y}' r='{radius}'>\
+                   <title>{title}</title>\
+                 </circle>\
+                 <text class='svg-ref-state-text' x='{x}' y='{concrete_y}'>{label}</text>\
+               </g>",
                 title = Self::escape_html(&node.title),
                 label = Self::escape_html(&node.label),
             );

--- a/src/refinement_mapping.rs
+++ b/src/refinement_mapping.rs
@@ -6,12 +6,36 @@ use std::{
     marker::PhantomData,
 };
 
+/// A refinement mapping from concrete model `C` into abstract model `A`.
+///
+/// A refinement mapping is defined by:
+///
+/// - an [`AuxState`](Self::AuxState) that evolves alongside the concrete
+///   execution (Lamport's *auxiliary variables* — see Abadi & Lamport,
+///   "The Existence of Refinement Mappings", 1991);
+/// - [`refinement_map`](Self::refinement_map): the function `f` that picks
+///   the abstract-state representative for a given `(concrete, aux)` pair;
+/// - [`Observable`](Self::Observable) + [`observe`](Self::observe): the
+///   observable interface — the contract the refinement preserves. The
+///   refinement check compares only observations, so `Observable` names
+///   what the concrete is required to simulate about the abstract.
+///
+/// Strict L-simulation is the special case where
+/// `type Observable = A::State` and `fn observe(a) { a.clone() }` — every
+/// field of the mapped abstract state is part of the contract. Choosing a
+/// smaller `Observable` projects internal bookkeeping out of the check.
 pub trait RefinementMapping<C, A>
 where
     C: Model,
     A: Model,
 {
-    type AuxState; // the auxiliary state for concrete model
+    /// Auxiliary / history state carried alongside the concrete execution.
+    /// Needed whenever the refinement mapping cannot be determined from
+    /// the current concrete state alone.
+    type AuxState;
+
+    /// The observable interface — the contract the refinement preserves.
+    type Observable: Clone + Eq + Debug;
 
     fn abstract_model(&self) -> &A;
 
@@ -25,7 +49,18 @@ where
         next_concrete: &C::State,
     ) -> Self::AuxState;
 
-    fn map_state(&self, concrete: &C::State, aux: &Self::AuxState) -> A::State;
+    /// The refinement mapping `f`: pick the abstract-state representative
+    /// for this `(concrete, aux)` pair. Load-bearing for L-simulation
+    /// search — the check needs a concrete `A::State` to pass to
+    /// `abstract_model.next_states(...)`.
+    fn refinement_map(&self, concrete: &C::State, aux: &Self::AuxState) -> A::State;
+
+    /// Project an abstract state to its observable interface. Called on
+    /// both sides of the refinement check:
+    ///
+    /// - concrete observations flow through `observe(refinement_map(c, aux))`
+    /// - abstract observations flow through `observe(a)` directly.
+    fn observe(&self, a: &A::State) -> Self::Observable;
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, PartialOrd)]
@@ -39,12 +74,14 @@ where
     aux_state: Map::AuxState,
     mapped_abstract_state: A::State,
 
-    // since "always" property will be checked after every state transition, we only need to store
-    // the prev and the cur state for refinement mapping check.
-    // prev is None when model state is the initial state. otherwise, it shouldn't be None.
+    // Since "always" properties are checked after every state transition, we
+    // only need the previous and current mapped abstract states to verify
+    // simulation. `prev` is `None` at initial states; non-`None` afterwards.
     prev_mapped_abstract_state: Option<A::State>,
 
-    // use this field to print out all the possible next states by providing the prev_mapped_abstract_state to the abstract model.
+    // Debug aid: all possible next abstract states reachable from
+    // `prev_mapped_abstract_state` via the abstract model. Useful for
+    // diagnosing which abstract transition (if any) matched.
     debug_from_prev_all: Vec<A::State>,
 }
 
@@ -53,66 +90,63 @@ pub struct RefinementModel<C, A, Map>
 where
     C: Model,
     A: Model,
-    A::State: PartialEq,
     Map: RefinementMapping<C, A>,
 {
     concrete: C,
     mapper: Map,
-    _phatom: PhantomData<A>,
+    _phantom: PhantomData<A>,
 }
 
 impl<C, A, Map> RefinementModel<C, A, Map>
 where
     C: Model,
     A: Model,
-    A::State: PartialEq,
     Map: RefinementMapping<C, A>,
 {
     pub fn new(concrete: C, mapper: Map) -> Self {
         Self {
             concrete,
             mapper,
-            _phatom: PhantomData,
+            _phantom: PhantomData,
         }
     }
 
     fn check_simulation(model: &Self, state: &RefinementModelState<C, A, Map>) -> bool {
         //
-        // (prev_mapped_abstract) ----------abstract_action-----------> (cur_mapped_abstract)
-        //          ^                                                           ^
-        //          |                                                           |
-        //          f                                                           f
-        //          |                                                           |
-        //          |                                                           |
-        // (prev_concrete, prev_aux) ---------concrete_action--------> (cur_concrete, cur_aux)
+        // (prev_mapped_abstract) ---------- abstract transition ---------> (cur_mapped_abstract)
+        //          ^                                                              ^
+        //          |                                                              |
+        //          f                                                              f
+        //          |                                                              |
+        //          |                                                              |
+        // (prev_concrete, prev_aux) --- concrete transition --> (cur_concrete, cur_aux)
         //
-        // To prove correspondence, we need to prove that:
-        // prev_mapped_abstract ------------abstract_action------------> mapped_abstract
-        //                                                                      ||
-        //                                                                      ||
-        // (prev_concrete, prev_aux) --> (cur_concrete, cur_aux) --f--> cur_mapped_abstract
+        // Weak L-simulation on `Observable`:
+        //   observe(prev_mapped_abstract) == observe(cur_mapped_abstract)    (stutter)
+        //   OR
+        //   there exists an abstract transition from `prev_mapped_abstract`
+        //   whose next state's observation equals
+        //   `observe(cur_mapped_abstract)`.
 
         let abstract_model = model.mapper.abstract_model();
-        let cur_mapped_abstract = &state.mapped_abstract_state;
+        let cur_abs = &state.mapped_abstract_state;
+        let cur_obs = model.mapper.observe(cur_abs);
+
         match &state.prev_mapped_abstract_state {
-            Some(prev_mapped_abstract) => {
-                if prev_mapped_abstract == cur_mapped_abstract {
-                    // stuttering step
+            Some(prev_abs) => {
+                if model.mapper.observe(prev_abs) == cur_obs {
+                    // stutter on the observable
                     return true;
                 }
-                // check L-simulation
                 abstract_model
-                    .next_states(prev_mapped_abstract)
+                    .next_states(prev_abs)
                     .iter()
-                    .any(|mapped_abstract| mapped_abstract == cur_mapped_abstract)
+                    .any(|next_abs| model.mapper.observe(next_abs) == cur_obs)
             }
-            None => {
-                // check if cur_mapped_abstract is a valid initial states of the abstract model
-                abstract_model
-                    .init_states()
-                    .iter()
-                    .any(|valid_init| valid_init == cur_mapped_abstract)
-            }
+            None => abstract_model
+                .init_states()
+                .iter()
+                .any(|init_abs| model.mapper.observe(init_abs) == cur_obs),
         }
     }
 
@@ -153,7 +187,7 @@ where
             .into_iter()
             .map(|concrete_state| {
                 let aux_state = self.mapper.init_aux_state(&concrete_state);
-                let mapped_abstract_state = self.mapper.map_state(&concrete_state, &aux_state);
+                let mapped_abstract_state = self.mapper.refinement_map(&concrete_state, &aux_state);
                 RefinementModelState {
                     concrete_state,
                     aux_state,
@@ -180,7 +214,7 @@ where
             &action,
             &next_concrete,
         );
-        let next_mapped_abstract = self.mapper.map_state(&next_concrete, &next_aux);
+        let next_mapped_abstract = self.mapper.refinement_map(&next_concrete, &next_aux);
 
         let debug_from_prev_all = self
             .mapper
@@ -219,18 +253,20 @@ where
             )
         };
 
-        let mut abstract_slots = HashMap::new();
-        let mut concrete_slots = HashMap::new();
+        // Concrete layer: dedup by full-state fingerprint.
+        // Abstract layer: dedup by Observable equivalence (linear scan).
+        // Middle layer: one node per step (no dedup).
+        let mut concrete_slots: HashMap<u64, usize> = HashMap::new();
 
-        let mut abstract_nodes = Vec::new();
-        let mut concrete_nodes = Vec::new();
-        let mut middle_nodes = Vec::new();
+        let mut abstract_nodes: Vec<(Map::Observable, NodeMeta)> = Vec::new();
+        let mut concrete_nodes: Vec<NodeMeta> = Vec::new();
+        let mut middle_nodes: Vec<NodeMeta> = Vec::new();
 
-        let mut abstract_path_slots = Vec::new();
-        let mut concrete_path_slots = Vec::new();
+        let mut abstract_path_slots: Vec<usize> = Vec::new();
+        let mut concrete_path_slots: Vec<usize> = Vec::new();
 
         for (step_idx, (state, _)) in steps.iter().enumerate() {
-            // Concrete (deduped)
+            // Concrete (deduped by fingerprint)
             let concrete_fp = fingerprint(&state.concrete_state).get();
             let concrete_slot = *concrete_slots.entry(concrete_fp).or_insert_with(|| {
                 let slot = concrete_nodes.len();
@@ -247,7 +283,7 @@ where
             });
             concrete_path_slots.push(concrete_slot);
 
-            // Concrete + Aux (per step)
+            // Concrete + Aux (per step, no dedup)
             let combo_fp =
                 fingerprint(&(state.concrete_state.clone(), state.aux_state.clone())).get();
             middle_nodes.push(NodeMeta {
@@ -263,21 +299,35 @@ where
                 ),
             });
 
-            // Abstract (deduped)
-            let abstract_fp = fingerprint(&state.mapped_abstract_state).get();
-            let abstract_slot = *abstract_slots.entry(abstract_fp).or_insert_with(|| {
-                let slot = abstract_nodes.len();
-                abstract_nodes.push(NodeMeta {
-                    label: format!("A{slot}"),
-                    title: build_title(
+            // Abstract (deduped by Observable equivalence via linear scan)
+            let obs = self.mapper.observe(&state.mapped_abstract_state);
+            let abstract_slot = match abstract_nodes
+                .iter()
+                .position(|(existing_obs, _)| *existing_obs == obs)
+            {
+                Some(slot) => slot,
+                None => {
+                    let slot = abstract_nodes.len();
+                    let abs_fp = fingerprint(&state.mapped_abstract_state).get();
+                    let title = build_title(
                         "Abstract",
                         slot,
-                        abstract_fp,
-                        format!("{:#?}", state.mapped_abstract_state),
-                    ),
-                });
-                slot
-            });
+                        abs_fp,
+                        format!(
+                            "Observable: {:#?}\n\nMapped abstract state: {:#?}",
+                            obs, state.mapped_abstract_state
+                        ),
+                    );
+                    abstract_nodes.push((
+                        obs.clone(),
+                        NodeMeta {
+                            label: format!("A{slot}"),
+                            title,
+                        },
+                    ));
+                    slot
+                }
+            };
             abstract_path_slots.push(abstract_slot);
         }
 
@@ -405,7 +455,7 @@ where
         }
 
         // Abstract nodes
-        for (slot_idx, node) in abstract_nodes.iter().enumerate() {
+        for (slot_idx, (_, node)) in abstract_nodes.iter().enumerate() {
             let x = left_padding + slot_idx * horizontal_gap;
             let _ = write!(
                 &mut svg,
@@ -454,5 +504,218 @@ where
 
         svg.push_str("</svg>");
         Some(svg)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Checker;
+
+    // ------------------------------------------------------------
+    // Toy concrete/abstract pair used by all tests below.
+    //
+    // Abstract: a monotonic counter plus an internal `ticks` field that
+    // increments on every step. `ticks` is "bookkeeping" — depending on
+    // the mapper's choice of Observable it may or may not be part of the
+    // refinement contract.
+    //
+    // Concrete: the same counter without `ticks` (the concrete doesn't
+    // track it). A mapper has to decide how to populate `ticks` in the
+    // mapped abstract state.
+    // ------------------------------------------------------------
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    struct AbsState {
+        counter: u32,
+        ticks: u32,
+    }
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    struct AbsAction;
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    struct AbsModel {
+        max_counter: u32,
+    }
+
+    impl Model for AbsModel {
+        type State = AbsState;
+        type Action = AbsAction;
+
+        fn init_states(&self) -> Vec<Self::State> {
+            vec![AbsState {
+                counter: 0,
+                ticks: 0,
+            }]
+        }
+
+        fn actions(&self, state: &Self::State, actions: &mut Vec<Self::Action>) {
+            if state.counter < self.max_counter {
+                actions.push(AbsAction);
+            }
+        }
+
+        fn next_state(&self, last: &Self::State, _: Self::Action) -> Option<Self::State> {
+            Some(AbsState {
+                counter: last.counter + 1,
+                ticks: last.ticks + 1,
+            })
+        }
+    }
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    struct ConState {
+        counter: u32,
+    }
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    struct ConAction;
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    struct ConModel {
+        max_counter: u32,
+    }
+
+    impl Model for ConModel {
+        type State = ConState;
+        type Action = ConAction;
+
+        fn init_states(&self) -> Vec<Self::State> {
+            vec![ConState { counter: 0 }]
+        }
+
+        fn actions(&self, state: &Self::State, actions: &mut Vec<Self::Action>) {
+            if state.counter < self.max_counter {
+                actions.push(ConAction);
+            }
+        }
+
+        fn next_state(&self, last: &Self::State, _: Self::Action) -> Option<Self::State> {
+            Some(ConState {
+                counter: last.counter + 1,
+            })
+        }
+    }
+
+    // --- Test 1: strict simulation (Observable = AbsState). The mapper
+    // sets `ticks = 0` always, which does NOT match the abstract's
+    // progression. Under the strict Observable this is visible and the
+    // check must fail. ---
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    struct StrictGarbageMapper {
+        abstract_model: AbsModel,
+    }
+
+    impl RefinementMapping<ConModel, AbsModel> for StrictGarbageMapper {
+        type AuxState = ();
+        type Observable = AbsState;
+
+        fn abstract_model(&self) -> &AbsModel {
+            &self.abstract_model
+        }
+
+        fn init_aux_state(&self, _: &ConState) -> () {}
+        fn advance_aux_state(&self, _: &ConState, _: &(), _: &ConAction, _: &ConState) -> () {}
+
+        fn refinement_map(&self, c: &ConState, _: &()) -> AbsState {
+            AbsState {
+                counter: c.counter,
+                ticks: 0, // garbage
+            }
+        }
+
+        fn observe(&self, a: &AbsState) -> AbsState {
+            a.clone()
+        }
+    }
+
+    #[test]
+    fn strict_observable_fails_when_bookkeeping_diverges() {
+        let concrete = ConModel { max_counter: 3 };
+        let abstract_ = AbsModel { max_counter: 3 };
+        let mapper = StrictGarbageMapper {
+            abstract_model: abstract_,
+        };
+        let model = RefinementModel::new(concrete, mapper);
+        let checker = model.checker().spawn_bfs().join();
+        assert!(
+            checker.discovery("check_simulation").is_some(),
+            "strict Observable should fail when refinement_map produces garbage ticks"
+        );
+    }
+
+    // --- Test 2: weak simulation — Observable hides `ticks`. Same broken
+    // mapper logic as test 1, now the check passes because bookkeeping is
+    // invisible. ---
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct CounterObs {
+        counter: u32,
+    }
+
+    #[derive(Clone, Debug, Hash, PartialEq, Eq)]
+    struct WeakTicksMapper {
+        abstract_model: AbsModel,
+    }
+
+    impl RefinementMapping<ConModel, AbsModel> for WeakTicksMapper {
+        type AuxState = ();
+        type Observable = CounterObs;
+
+        fn abstract_model(&self) -> &AbsModel {
+            &self.abstract_model
+        }
+
+        fn init_aux_state(&self, _: &ConState) -> () {}
+        fn advance_aux_state(&self, _: &ConState, _: &(), _: &ConAction, _: &ConState) -> () {}
+
+        fn refinement_map(&self, c: &ConState, _: &()) -> AbsState {
+            AbsState {
+                counter: c.counter,
+                ticks: 0, // still garbage — but ignored by `observe`
+            }
+        }
+
+        fn observe(&self, a: &AbsState) -> CounterObs {
+            CounterObs { counter: a.counter }
+        }
+    }
+
+    #[test]
+    fn weak_observable_passes_when_bookkeeping_hidden() {
+        let concrete = ConModel { max_counter: 3 };
+        let abstract_ = AbsModel { max_counter: 3 };
+        let mapper = WeakTicksMapper {
+            abstract_model: abstract_,
+        };
+        let model = RefinementModel::new(concrete, mapper);
+        let checker = model.checker().spawn_bfs().join();
+        assert!(
+            checker.discovery("check_simulation").is_none(),
+            "Observable projecting away `ticks` should accept the mapping"
+        );
+    }
+
+    // --- Test 3: L-simulation match via `observe` across a longer trace.
+    // Every concrete step must find an abstract transition whose next
+    // state's observation matches — exercising the `any` search, not
+    // just stutters. ---
+
+    #[test]
+    fn weak_observable_matches_abstract_transitions() {
+        let concrete = ConModel { max_counter: 8 };
+        let abstract_ = AbsModel { max_counter: 8 };
+        let mapper = WeakTicksMapper {
+            abstract_model: abstract_,
+        };
+        let model = RefinementModel::new(concrete, mapper);
+        let checker = model.checker().spawn_bfs().join();
+        assert!(
+            checker.discovery("check_simulation").is_none(),
+            "L-simulation should match via observe across the full trace"
+        );
+        assert!(checker.state_count() >= 8);
     }
 }

--- a/src/refinement_mapping.rs
+++ b/src/refinement_mapping.rs
@@ -616,8 +616,8 @@ mod tests {
             &self.abstract_model
         }
 
-        fn init_aux_state(&self, _: &ConState) -> () {}
-        fn advance_aux_state(&self, _: &ConState, _: &(), _: &ConAction, _: &ConState) -> () {}
+        fn init_aux_state(&self, _: &ConState) {}
+        fn advance_aux_state(&self, _: &ConState, _: &(), _: &ConAction, _: &ConState) {}
 
         fn refinement_map(&self, c: &ConState, _: &()) -> AbsState {
             AbsState {
@@ -668,8 +668,8 @@ mod tests {
             &self.abstract_model
         }
 
-        fn init_aux_state(&self, _: &ConState) -> () {}
-        fn advance_aux_state(&self, _: &ConState, _: &(), _: &ConAction, _: &ConState) -> () {}
+        fn init_aux_state(&self, _: &ConState) {}
+        fn advance_aux_state(&self, _: &ConState, _: &(), _: &ConAction, _: &ConState) {}
 
         fn refinement_map(&self, c: &ConState, _: &()) -> AbsState {
             AbsState {

--- a/src/refinement_mapping.rs
+++ b/src/refinement_mapping.rs
@@ -63,7 +63,7 @@ where
     fn observe(&self, a: &A::State) -> Self::Observable;
 }
 
-#[derive(Debug, Clone, Hash, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Hash, PartialEq)]
 pub struct RefinementModelState<C, A, Map>
 where
     C: Model,
@@ -78,11 +78,6 @@ where
     // only need the previous and current mapped abstract states to verify
     // simulation. `prev` is `None` at initial states; non-`None` afterwards.
     prev_mapped_abstract_state: Option<A::State>,
-
-    // Debug aid: all possible next abstract states reachable from
-    // `prev_mapped_abstract_state` via the abstract model. Useful for
-    // diagnosing which abstract transition (if any) matched.
-    debug_from_prev_all: Vec<A::State>,
 }
 
 #[derive(Debug)]
@@ -101,6 +96,7 @@ impl<C, A, Map> RefinementModel<C, A, Map>
 where
     C: Model,
     A: Model,
+    A::State: PartialEq,
     Map: RefinementMapping<C, A>,
 {
     pub fn new(concrete: C, mapper: Map) -> Self {
@@ -130,12 +126,18 @@ where
 
         let abstract_model = model.mapper.abstract_model();
         let cur_abs = &state.mapped_abstract_state;
-        let cur_obs = model.mapper.observe(cur_abs);
 
         match &state.prev_mapped_abstract_state {
             Some(prev_abs) => {
+                // Fast path: if the mapped abstract states are fully identical,
+                // it's a stutter regardless of the observable — no observe() call
+                // and no next_states allocation needed.
+                if prev_abs == cur_abs {
+                    return true;
+                }
+                let cur_obs = model.mapper.observe(cur_abs);
                 if model.mapper.observe(prev_abs) == cur_obs {
-                    // stutter on the observable
+                    // observable-level stutter (weak-sim case)
                     return true;
                 }
                 abstract_model
@@ -143,10 +145,13 @@ where
                     .iter()
                     .any(|next_abs| model.mapper.observe(next_abs) == cur_obs)
             }
-            None => abstract_model
-                .init_states()
-                .iter()
-                .any(|init_abs| model.mapper.observe(init_abs) == cur_obs),
+            None => {
+                let cur_obs = model.mapper.observe(cur_abs);
+                abstract_model
+                    .init_states()
+                    .iter()
+                    .any(|init_abs| model.mapper.observe(init_abs) == cur_obs)
+            }
         }
     }
 
@@ -193,7 +198,6 @@ where
                     aux_state,
                     mapped_abstract_state,
                     prev_mapped_abstract_state: None,
-                    debug_from_prev_all: vec![],
                 }
             })
             .collect()
@@ -216,17 +220,11 @@ where
         );
         let next_mapped_abstract = self.mapper.refinement_map(&next_concrete, &next_aux);
 
-        let debug_from_prev_all = self
-            .mapper
-            .abstract_model()
-            .next_states(&last_state.mapped_abstract_state);
-
         Some(RefinementModelState {
             concrete_state: next_concrete,
             aux_state: next_aux,
             mapped_abstract_state: next_mapped_abstract,
             prev_mapped_abstract_state: Some(last_state.mapped_abstract_state.clone()),
-            debug_from_prev_all,
         })
     }
 

--- a/src/refinement_mapping.rs
+++ b/src/refinement_mapping.rs
@@ -1,0 +1,171 @@
+use crate::{Model, Property};
+use std::marker::PhantomData;
+
+pub trait RefinementMapping<C, A>
+where
+    C: Model,
+    A: Model,
+{
+    type AuxState; // the auxiliary state for concrete model
+
+    fn abstract_model(&self) -> &A;
+
+    fn init_aux_state(&self, concrete: &C::State) -> Self::AuxState;
+
+    fn advance_aux_state(
+        &self,
+        last_concrete: &C::State,
+        last_aux: &Self::AuxState,
+        action: &C::Action,
+        next_concrete: &C::State,
+    ) -> Self::AuxState;
+
+    fn map_state(&self, concrete: &C::State, aux: &Self::AuxState) -> A::State;
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, PartialOrd)]
+pub struct RefinementModelState<C, A, Map>
+where
+    C: Model,
+    A: Model,
+    Map: RefinementMapping<C, A>,
+{
+    concrete_state: C::State,
+    aux_state: Map::AuxState,
+    mapped_abstract_state: A::State,
+
+    // since "always" property will be checked after every state transition, we only need to store
+    // the prev and the cur state for refinement mapping check.
+    // prev is None when model state is the initial state. otherwise, it shouldn't be None.
+    prev_mapped_abstract_state: Option<A::State>,
+}
+
+#[derive(Debug)]
+pub struct RefinementModel<C, A, Map>
+where
+    C: Model,
+    A: Model,
+    A::State: PartialEq,
+    Map: RefinementMapping<C, A>,
+{
+    concrete: C,
+    mapper: Map,
+    _phatom: PhantomData<A>,
+}
+
+impl<C, A, Map> RefinementModel<C, A, Map>
+where
+    C: Model,
+    A: Model,
+    A::State: PartialEq,
+    Map: RefinementMapping<C, A>,
+{
+    pub fn new(concrete: C, mapper: Map) -> Self {
+        Self {
+            concrete,
+            mapper,
+            _phatom: PhantomData,
+        }
+    }
+
+    fn check_simulation(model: &Self, state: &RefinementModelState<C, A, Map>) -> bool {
+        //
+        // (prev_mapped_abstract) ----------abstract_action-----------> (cur_mapped_abstract)
+        //          ^                                                           ^
+        //          |                                                           |
+        //          f                                                           f
+        //          |                                                           |
+        //          |                                                           |
+        // (prev_concrete, prev_aux) ---------concrete_action--------> (cur_concrete, cur_aux)
+        //
+        // To prove correspondence, we need to prove that:
+        // prev_mapped_abstract ------------abstract_action------------> mapped_abstract
+        //                                                                      ||
+        //                                                                      ||
+        // (prev_concrete, prev_aux) --> (cur_concrete, cur_aux) --f--> cur_mapped_abstract
+
+        let abstract_model = model.mapper.abstract_model();
+        let cur_mapped_abstract = &state.mapped_abstract_state;
+        match &state.prev_mapped_abstract_state {
+            Some(prev_mapped_abstract) => {
+                if prev_mapped_abstract == cur_mapped_abstract {
+                    // stuttering step
+                    return true;
+                }
+                // check L-simulation
+                abstract_model
+                    .next_states(prev_mapped_abstract)
+                    .iter()
+                    .any(|mapped_abstract| mapped_abstract == cur_mapped_abstract)
+            }
+            None => {
+                // check if cur_mapped_abstract is a valid initial states of the abstract model
+                abstract_model
+                    .init_states()
+                    .iter()
+                    .any(|valid_init| valid_init == cur_mapped_abstract)
+            }
+        }
+    }
+}
+
+impl<C, A, Map> Model for RefinementModel<C, A, Map>
+where
+    C: Model,
+    C::Action: Clone,
+    C::State: Clone,
+    A: Model,
+    A::State: Clone + PartialEq,
+    Map: RefinementMapping<C, A>,
+    Map::AuxState: Clone,
+{
+    type State = RefinementModelState<C, A, Map>;
+
+    type Action = C::Action;
+
+    fn init_states(&self) -> Vec<Self::State> {
+        self.concrete
+            .init_states()
+            .into_iter()
+            .map(|concrete_state| {
+                let aux_state = self.mapper.init_aux_state(&concrete_state);
+                let mapped_abstract_state = self.mapper.map_state(&concrete_state, &aux_state);
+                RefinementModelState {
+                    concrete_state,
+                    aux_state,
+                    mapped_abstract_state,
+                    prev_mapped_abstract_state: None,
+                }
+            })
+            .collect()
+    }
+
+    fn actions(&self, state: &Self::State, actions: &mut Vec<Self::Action>) {
+        // action should be the same as the concrete model's action
+        self.concrete.actions(&state.concrete_state, actions);
+    }
+
+    fn next_state(&self, last_state: &Self::State, action: Self::Action) -> Option<Self::State> {
+        let next_concrete = self
+            .concrete
+            .next_state(&last_state.concrete_state, action.clone())?;
+        let next_aux = self.mapper.advance_aux_state(
+            &last_state.concrete_state,
+            &last_state.aux_state,
+            &action,
+            &next_concrete,
+        );
+        let next_mapped_abstract = self.mapper.map_state(&next_concrete, &next_aux);
+
+        Some(RefinementModelState {
+            concrete_state: next_concrete,
+            aux_state: next_aux,
+            mapped_abstract_state: next_mapped_abstract,
+            prev_mapped_abstract_state: Some(last_state.mapped_abstract_state.clone()),
+        })
+    }
+
+    fn properties(&self) -> Vec<Property<Self>> {
+        vec![Property::always("check_simulation", Self::check_simulation)]
+    }
+}

--- a/src/refinement_mapping.rs
+++ b/src/refinement_mapping.rs
@@ -212,11 +212,6 @@ where
             title: String,
         }
 
-        let mut abstract_slots: HashMap<u64, usize> = HashMap::new();
-        let mut abstract_nodes = Vec::new();
-        let mut concrete_nodes = Vec::new();
-        let mut mapping_slots = Vec::new();
-
         let build_title = |kind: &str, idx: usize, fp: u64, value: String| -> String {
             format!(
                 "{kind} state #{idx}\nfingerprint=0x{fp:016x}\n{value}",
@@ -224,8 +219,14 @@ where
             )
         };
 
-        for (step_idx, (state, _)) in steps.iter().enumerate() {
-            // Concrete node metadata always uses the step index.
+        let mut abstract_slots = HashMap::new();
+        let mut abstract_nodes = Vec::new();
+        let mut abstract_path_slots = Vec::new();
+        let mut concrete_nodes = Vec::new();
+        let mut mapping_slots = Vec::new();
+
+        for (step_idx, (state, _action)) in steps.iter().enumerate() {
+            // Concrete node
             let concrete_fp = fingerprint(&state.concrete_state).get();
             concrete_nodes.push(NodeMeta {
                 label: format!("C{step_idx}"),
@@ -237,7 +238,7 @@ where
                 ),
             });
 
-            // Abstract nodes dedupe via fingerprint/slot.
+            // Abstract node (deduped via fingerprint)
             let abstract_fp = fingerprint(&state.mapped_abstract_state).get();
             let slot = *abstract_slots.entry(abstract_fp).or_insert_with(|| {
                 let slot_idx = abstract_nodes.len();
@@ -252,8 +253,12 @@ where
                 });
                 slot_idx
             });
+            abstract_path_slots.push(slot);
             mapping_slots.push(slot);
         }
+
+        let last_state = &steps.last().unwrap().0;
+        let last_is_valid = Self::check_simulation(self, last_state);
 
         let horizontal_gap = 150usize;
         let vertical_gap = 160usize;
@@ -291,45 +296,65 @@ where
            <text class='svg-ref-label' x='20' y='{concrete_y}'>Concrete Model</text>"
         );
 
-        // Concrete transition edges (solid, sequential).
+        // Concrete transitions
         for window in (0..concrete_nodes.len()).collect::<Vec<_>>().windows(2) {
             if let [left, right] = window {
                 let _ = write!(
-                  &mut svg,
-                  "<line x1='{x1}' y1='{con_y}' x2='{x2}' y2='{con_y}' class='svg-ref-edge' marker-end='url(#refinement-arrow)'/>",
-                  x1 = left_padding + left * horizontal_gap,
-                  x2 = left_padding + right * horizontal_gap,
-                  con_y = concrete_y,
-              );
+                    &mut svg,
+                    "<line x1='{x1}' y1='{concrete_y}' x2='{x2}' y2='{concrete_y}' \
+                     class='svg-ref-edge' marker-end='url(#refinement-arrow)'/>",
+                    x1 = left_padding + left * horizontal_gap,
+                    x2 = left_padding + right * horizontal_gap,
+                );
             }
         }
 
-        // Abstract transition edges (solid between slot ordering).
-        for window in (0..abstract_nodes.len()).collect::<Vec<_>>().windows(2) {
-            if let [left, right] = window {
-                let _ = write!(
-                  &mut svg,
-                  "<line x1='{x1}' y1='{abs_y}' x2='{x2}' y2='{abs_y}' class='svg-ref-edge' marker-end='url(#refinement-arrow)'/>",
-                  x1 = left_padding + left * horizontal_gap,
-                  x2 = left_padding + right * horizontal_gap,
-                  abs_y = abstract_y,
-              );
+        // Abstract transitions (mark final edge dashed if last state invalid)
+        for i in 1..abstract_path_slots.len() {
+            let start_slot = abstract_path_slots[i - 1];
+            let end_slot = abstract_path_slots[i];
+            let x1 = left_padding + start_slot * horizontal_gap;
+            let x2 = left_padding + end_slot * horizontal_gap;
+            let mut class = "svg-ref-edge";
+            let mut cross = None;
+            if i == abstract_path_slots.len() - 1 && !last_is_valid {
+                class = "svg-ref-edge svg-ref-edge-invalid";
+                let mid_x = (x1 + x2) / 2;
+                let size = 10;
+                cross = Some((
+                    mid_x - size,
+                    mid_x + size,
+                    abstract_y - size,
+                    abstract_y + size,
+                ));
             }
-        }
-
-        // Mapping lines from each concrete state to its abstract slot.
-        for (step_idx, slot_idx) in mapping_slots.into_iter().enumerate() {
             let _ = write!(
                 &mut svg,
-                "<line x1='{x1}' y1='{y1}' x2='{x2}' y2='{y2}' class='svg-ref-mapping-line'/>",
-                x1 = left_padding + step_idx * horizontal_gap,
+                "<line x1='{x1}' y1='{abstract_y}' x2='{x2}' y2='{abstract_y}' \
+                 class='{class}' marker-end='url(#refinement-arrow)'/>",
+            );
+            if let Some((mx1, mx2, my1, my2)) = cross {
+                let _ = write!(
+                  &mut svg,
+                  "<line x1='{mx1}' y1='{my1}' x2='{mx2}' y2='{my2}' class='svg-ref-invalid-cross'/>\
+                   <line x1='{mx1}' y1='{my2}' x2='{mx2}' y2='{my1}' class='svg-ref-invalid-cross'/>",
+              );
+            }
+        }
+
+        // Mapping lines
+        for (step_idx, slot_idx) in mapping_slots.iter().enumerate() {
+            let _ = write!(
+                &mut svg,
+                "<line x1='{cx}' y1='{y1}' x2='{ax}' y2='{y2}' class='svg-ref-mapping-line'/>",
+                cx = left_padding + step_idx * horizontal_gap,
                 y1 = concrete_y - radius,
-                x2 = left_padding + slot_idx * horizontal_gap,
+                ax = left_padding + slot_idx * horizontal_gap,
                 y2 = abstract_y + radius,
             );
         }
 
-        // Emit abstract circles.
+        // Abstract nodes
         for (slot_idx, node) in abstract_nodes.iter().enumerate() {
             let x = left_padding + slot_idx * horizontal_gap;
             let _ = write!(
@@ -345,7 +370,7 @@ where
             );
         }
 
-        // Emit concrete circles.
+        // Concrete nodes
         for (step_idx, node) in concrete_nodes.iter().enumerate() {
             let x = left_padding + step_idx * horizontal_gap;
             let _ = write!(

--- a/src/refinement_mapping.rs
+++ b/src/refinement_mapping.rs
@@ -1,5 +1,9 @@
-use crate::{Model, Property};
-use std::marker::PhantomData;
+use crate::{fingerprint, Model, Property};
+use std::{
+    fmt::{Debug, Write},
+    hash::Hash,
+    marker::PhantomData,
+};
 
 pub trait RefinementMapping<C, A>
 where
@@ -38,6 +42,9 @@ where
     // the prev and the cur state for refinement mapping check.
     // prev is None when model state is the initial state. otherwise, it shouldn't be None.
     prev_mapped_abstract_state: Option<A::State>,
+
+    // use this field to print out all the possible next states by providing the prev_mapped_abstract_state to the abstract model.
+    debug_from_prev_all: Vec<A::State>,
 }
 
 #[derive(Debug)]
@@ -107,15 +114,31 @@ where
             }
         }
     }
+
+    // helper function for producing svg
+    fn escape_html(input: &str) -> String {
+        let mut escaped = String::with_capacity(input.len());
+        for ch in input.chars() {
+            match ch {
+                '&' => escaped.push_str("&amp;"),
+                '<' => escaped.push_str("&lt;"),
+                '>' => escaped.push_str("&gt;"),
+                '"' => escaped.push_str("&quot;"),
+                '\'' => escaped.push_str("&#x27;"),
+                _ => escaped.push(ch),
+            }
+        }
+        escaped
+    }
 }
 
 impl<C, A, Map> Model for RefinementModel<C, A, Map>
 where
     C: Model,
     C::Action: Clone,
-    C::State: Clone,
+    C::State: Clone + Debug + Hash,
     A: Model,
-    A::State: Clone + PartialEq,
+    A::State: Clone + PartialEq + Debug + Hash,
     Map: RefinementMapping<C, A>,
     Map::AuxState: Clone,
 {
@@ -135,6 +158,7 @@ where
                     aux_state,
                     mapped_abstract_state,
                     prev_mapped_abstract_state: None,
+                    debug_from_prev_all: vec![],
                 }
             })
             .collect()
@@ -157,15 +181,151 @@ where
         );
         let next_mapped_abstract = self.mapper.map_state(&next_concrete, &next_aux);
 
+        let debug_from_prev_all = self
+            .mapper
+            .abstract_model()
+            .next_states(&last_state.mapped_abstract_state);
+
         Some(RefinementModelState {
             concrete_state: next_concrete,
             aux_state: next_aux,
             mapped_abstract_state: next_mapped_abstract,
             prev_mapped_abstract_state: Some(last_state.mapped_abstract_state.clone()),
+            debug_from_prev_all,
         })
     }
 
     fn properties(&self) -> Vec<Property<Self>> {
         vec![Property::always("check_simulation", Self::check_simulation)]
+    }
+
+    fn as_svg(&self, path: crate::Path<Self::State, Self::Action>) -> Option<String> {
+        let steps = path.into_vec();
+        if steps.is_empty() {
+            return None;
+        }
+
+        struct Node {
+            x: usize,
+            y: usize,
+            label: String,
+            title: String,
+        }
+
+        let node_count = steps.len();
+        let horizontal_gap = 150usize;
+        let vertical_gap = 160usize;
+        let left_padding = 140usize;
+        let right_padding = 120usize;
+        let top_padding = 80usize;
+        let radius = 22usize;
+        let width = left_padding
+            + right_padding
+            + horizontal_gap.saturating_mul(node_count.saturating_sub(1));
+        let height = top_padding * 2 + vertical_gap;
+        let abstract_y = top_padding;
+        let concrete_y = top_padding + vertical_gap;
+
+        let build_title = |kind: &str, idx: usize, fp: u64, value: String| -> String {
+            format!(
+                "{kind} state #{idx}\nfingerprint=0x{fp:016x}\n{value}",
+                value = value
+            )
+        };
+
+        let mut abstract_nodes = Vec::with_capacity(node_count);
+        let mut concrete_nodes = Vec::with_capacity(node_count);
+        for (idx, (state, _)) in steps.iter().enumerate() {
+            let x = left_padding + idx * horizontal_gap;
+            let abstract_fp = fingerprint(&state.mapped_abstract_state).get();
+            let concrete_fp = fingerprint(&state.concrete_state).get();
+            abstract_nodes.push(Node {
+                x,
+                y: abstract_y,
+                label: format!("A{idx}"),
+                title: build_title(
+                    "Abstract",
+                    idx,
+                    abstract_fp,
+                    format!("{:#?}", state.mapped_abstract_state),
+                ),
+            });
+            concrete_nodes.push(Node {
+                x,
+                y: concrete_y,
+                label: format!("C{idx}"),
+                title: build_title(
+                    "Concrete",
+                    idx,
+                    concrete_fp,
+                    format!("{:#?}", state.concrete_state),
+                ),
+            });
+        }
+
+        let mut svg = String::new();
+        let _ = write!(
+            &mut svg,
+            "<svg version='1.1' baseProfile='full' width='{width}' height='{height}' \
+           viewBox='0 0 {width} {height}' xmlns='http://www.w3.org/2000/svg'>"
+        );
+        let _ = write!(
+          &mut svg,
+          "<defs>\
+             <marker id='refinement-arrow' markerWidth='12' markerHeight='10' refX='12' refY='5' orient='auto'>\
+               <polygon points='0 0, 12 5, 0 10' class='svg-ref-edge-head'/>\
+             </marker>\
+           </defs>"
+      );
+        let _ = write!(
+            &mut svg,
+            "<text class='svg-ref-label' x='20' y='{abstract_y}'>Abstract</text>\
+           <text class='svg-ref-label' x='20' y='{concrete_y}'>Concrete+Aux</text>"
+        );
+
+        for nodes in [&abstract_nodes, &concrete_nodes] {
+            for window in nodes.windows(2) {
+                if let [left, right] = window {
+                    let _ = write!(
+                      &mut svg,
+                      "<line x1='{x1}' y1='{y1}' x2='{x2}' y2='{y2}' class='svg-ref-edge' marker-end='url(#refinement-arrow)'/>",
+                      x1 = left.x,
+                      y1 = left.y,
+                      x2 = right.x,
+                      y2 = right.y
+                  );
+                }
+            }
+        }
+
+        for (abstract_node, concrete_node) in abstract_nodes.iter().zip(concrete_nodes.iter()) {
+            let _ = write!(
+                &mut svg,
+                "<line x1='{x}' y1='{y1}' x2='{x}' y2='{y2}' class='svg-ref-mapping-line'/>",
+                x = abstract_node.x,
+                y1 = abstract_node.y + radius,
+                y2 = concrete_node.y - radius
+            );
+        }
+
+        for node in abstract_nodes.iter().chain(concrete_nodes.iter()) {
+            let _ = write!(
+                &mut svg,
+                "<g class='svg-ref-node'>\
+                 <circle class='svg-ref-state-circle' cx='{x}' cy='{y}' r='{radius}'>\
+                   <title>{title}</title>\
+                 </circle>\
+                 <text class='svg-ref-state-text' x='{x}' y='{y}'>{label}</text>\
+               </g>",
+                x = node.x,
+                y = node.y,
+                radius = radius,
+                title = Self::escape_html(&node.title),
+                label = Self::escape_html(&node.label),
+            );
+        }
+
+        svg.push_str("</svg>");
+        Some(svg)
     }
 }

--- a/ui/app.css
+++ b/ui/app.css
@@ -182,3 +182,35 @@ ul {
     fill: var(--bg-med);
     stroke: var(--bg-med);
 }
+.svg-ref-label {
+    fill: var(--fg-lit);
+    font-size: 14px;
+    font-weight: bold;
+}
+.svg-ref-state-circle {
+    fill: var(--bg-drk);
+    stroke: var(--contrast-brt);
+    stroke-width: 2;
+}
+.svg-ref-state-text {
+    fill: var(--fg-lit);
+    font-size: 12px;
+    font-weight: bold;
+    text-anchor: middle;
+    dominant-baseline: middle;
+}
+.svg-ref-edge {
+    fill: none;
+    stroke: var(--fg-lit);
+    stroke-width: 2;
+}
+.svg-ref-edge-head {
+    fill: var(--fg-lit);
+    stroke: var(--fg-lit);
+}
+.svg-ref-mapping-line {
+    fill: none;
+    stroke: var(--contrast-brt);
+    stroke-dasharray: 6 4;
+    stroke-width: 1.5;
+}

--- a/ui/app.css
+++ b/ui/app.css
@@ -214,3 +214,11 @@ ul {
     stroke-dasharray: 6 4;
     stroke-width: 1.5;
 }
+.svg-ref-edge-invalid {
+    stroke-dasharray: 6 4;
+    stroke: var(--fg-lit);
+}
+.svg-ref-invalid-cross {
+    stroke: var(--contrast-brt);
+    stroke-width: 2;
+}


### PR DESCRIPTION
## Summary

Brings the refinement-mapping feature to completion, culminating in weak-simulation support.

- Adds the `RefinementMapping<C, A>` trait: `AuxState`, `refinement_map` (Lamport's function `f`), `Observable`, and `observe` for projecting the abstract state to the refinement contract.
- Adds `RefinementModel`, a wrapper that embeds a concrete model, an abstract model, and a mapping into a single stateright `Model`. The refinement obligation is exposed as an always-property (`check_simulation`).
- Three-layer SVG counterexample visualization (Concrete / Concrete+Aux / Abstract) with dedup, invalid-edge highlighting, and observable-based abstract-layer grouping.
- Three examples:
  - `min_max.rs` — Lamport's MinMax paper, bidirectional refinement (MinMax1 ↔ MinMax2), demonstrates aux/history variables.
  - `multithreaded-counter.rs` — Hillel Wayne's blog example; bad impl fails refinement, good impl (with lock) passes.
  - `weak_counter.rs` — side-by-side strict-vs-weak demonstration on the same mapping.
- Closes ytong24/stateright#3: the new explicit `Observable` type lets the refinement check ignore internal/bookkeeping fields of the abstract state (weak simulation), rather than requiring full-state equality (strict).
- Perf cleanups: dropped unused `debug_from_prev_all` field, fast-path stutter check in `check_simulation` that skips `observe()` and `next_states()` allocation when the mapped abstract state is unchanged, dropped unused `PartialOrd` derive on `RefinementModelState`.

Closes #3